### PR TITLE
feature: log configuration to customize log output

### DIFF
--- a/air.conf.example
+++ b/air.conf.example
@@ -13,6 +13,9 @@ include_ext = ["go", "tpl", "tmpl", "html"]
 exclude_dir = ["assets", "tmp", "vendor", "frontend/node_modules"]
 delay = 800 # ms
 
+[log]
+time=true
+
 [color]
 main = "magenta"
 watcher = "cyan"

--- a/runner/config.go
+++ b/runner/config.go
@@ -21,6 +21,7 @@ type config struct {
 	TmpDir   string   `toml:"tmp_dir"`
 	Build    cfgBuild `toml:"build"`
 	Color    cfgColor `toml:"color"`
+	Log      cfgLog   `toml:"log"`
 }
 
 type cfgBuild struct {
@@ -30,6 +31,10 @@ type cfgBuild struct {
 	IncludeExt []string `toml:"include_ext"`
 	ExcludeDir []string `toml:"exclude_dir"`
 	Delay      int      `toml:"delay"`
+}
+
+type cfgLog struct {
+	AddTime bool `toml:"time"`
 }
 
 type cfgColor struct {
@@ -88,12 +93,16 @@ func defaultConfig() config {
 		Runner:  "green",
 		App:     "white",
 	}
+	log := cfgLog{
+		AddTime: true,
+	}
 	return config{
 		Root:     ".",
 		TmpDir:   "tmp",
 		WatchDir: "",
 		Build:    build,
 		Color:    color,
+		Log:      log,
 	}
 }
 


### PR DESCRIPTION
This PR introduces two minors changes to the logger:

**Change 1:** Skip the line feed if the message already ends with one. The problem is that when the running program outputs a log that ends with a line feed, Air is doubling it. This can also be seen here #8 and my attached screenshot. 

**Change 2:** Introduces a new configuration section to customize log messages. Most applications already include time on its log, so it'd be cleaner if we could just ignore this on Air to prevent double time being logged. This can also be seen here #8 and my attached screenshot. 

Bofore PR:

<img width="630" alt="screen shot 2018-05-11 at 20 00 29" src="https://user-images.githubusercontent.com/94755/39942240-cfcce34e-5556-11e8-9c2e-336ebe279dcf.png">

After PR:

<img width="517" alt="screen shot 2018-05-11 at 19 59 56" src="https://user-images.githubusercontent.com/94755/39942249-d667115c-5556-11e8-8d4e-3e2ac564677b.png">

