### PR TITLE
Update e.config.Root to get the Absolute path first

### DIFF
--- a/runner/engine.go
+++ b/runner/engine.go
@@ -63,9 +63,15 @@ func NewEngine(cfgPath string, debugMode bool) (*Engine, error) {
 
 // Run run run
 func (e *Engine) Run() {
+	abs, err := filepath.Abs(e.config.Root)
+	if err != nil {
+		os.Exit(1)
+	}
+
+	e.config.Root = abs
+
 	e.mainDebug("CWD: %s", e.config.Root)
 
-	var err error
 	if err = e.checkRunEnv(); err != nil {
 		os.Exit(1)
 	}


### PR DESCRIPTION
Resolves the absolute directory for `root` prior to running.