### PR TITLE
cmd.Process.Wait

### DIFF
--- a/runner/util_linux.go
+++ b/runner/util_linux.go
@@ -11,7 +11,11 @@ import (
 func killCmd(cmd *exec.Cmd) (int, error) {
 	pid := cmd.Process.Pid
 	// https://stackoverflow.com/questions/22470193/why-wont-go-kill-a-child-process-correctly
-	err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	err := syscall.Kill(-pid, syscall.SIGKILL)
+
+	// Wait releases any resources associated with the Process.
+	_, _ = cmd.Process.Wait()
+
 	return pid, err
 }
 


### PR DESCRIPTION
I observe some processes not killed, after hot-reload.
Right after start:
![start](https://user-images.githubusercontent.com/50022872/73777020-c3df9680-4799-11ea-8137-4a435e6ea6af.png)
After some reloads:
![later](https://user-images.githubusercontent.com/50022872/73777045-ce019500-4799-11ea-86c6-b605df171f61.png)

I tested this issue on my apps, and on [gin graceful-shutdown](https://github.com/gin-gonic/examples/tree/master/graceful-shutdown/graceful-shutdown) example ([my test code](https://github.com/wsnotify/air-test)).
This addition fixes the problem.