### PR TITLE
SIGINT

### DIFF
--- a/air_example.conf
+++ b/air_example.conf
@@ -26,7 +26,7 @@ delay = 1000 # ms
 stop_on_error = true
 # This log file places in your tmp_dir.
 log = "air_errors.log"
-# Send Interrupt signal before killing process
+# Send Interrupt signal before killing process (windows does not support this feature)
 send_interrupt = false
 # Delay after sending Interrupt signal
 kill_delay = 0

--- a/air_example.conf
+++ b/air_example.conf
@@ -2,7 +2,7 @@
 
 # Working directory
 # . or absolute path, please note that the directories following must be under root.
-root = "." 
+root = "."
 tmp_dir = "tmp"
 
 [build]
@@ -26,6 +26,10 @@ delay = 1000 # ms
 stop_on_error = true
 # This log file places in your tmp_dir.
 log = "air_errors.log"
+# Send Interrupt signal before killing process
+send_interrupt = false
+# Delay after sending Interrupt signal
+kill_delay = 0
 
 [log]
 # Show log time

--- a/runner/config.go
+++ b/runner/config.go
@@ -26,16 +26,18 @@ type config struct {
 }
 
 type cfgBuild struct {
-	Cmd         string   `toml:"cmd"`
-	Bin         string   `toml:"bin"`
-	FullBin     string   `toml:"full_bin"`
-	Log         string   `toml:"log"`
-	IncludeExt  []string `toml:"include_ext"`
-	ExcludeDir  []string `toml:"exclude_dir"`
-	IncludeDir  []string `toml:"include_dir"`
-	ExcludeFile []string `toml:"exclude_file"`
-	Delay       int      `toml:"delay"`
-	StopOnError bool     `toml:"stop_on_error"`
+	Cmd           string        `toml:"cmd"`
+	Bin           string        `toml:"bin"`
+	FullBin       string        `toml:"full_bin"`
+	Log           string        `toml:"log"`
+	IncludeExt    []string      `toml:"include_ext"`
+	ExcludeDir    []string      `toml:"exclude_dir"`
+	IncludeDir    []string      `toml:"include_dir"`
+	ExcludeFile   []string      `toml:"exclude_file"`
+	Delay         int           `toml:"delay"`
+	StopOnError   bool          `toml:"stop_on_error"`
+	SendInterrupt bool          `toml:"send_interrupt"`
+	KillDelay     time.Duration `toml:"kill_delay"`
 }
 
 type cfgLog struct {

--- a/runner/engine.go
+++ b/runner/engine.go
@@ -312,7 +312,7 @@ func (e *Engine) runBin() error {
 		}()
 
 		var err error
-		pid, err := killCmd(cmd)
+		pid, err := e.killCmd(cmd)
 		if err != nil {
 			e.mainDebug("failed to kill PID %d, error: %s", pid, err.Error())
 			if cmd.ProcessState != nil && !cmd.ProcessState.Exited() {

--- a/runner/util_darwin.go
+++ b/runner/util_darwin.go
@@ -4,14 +4,29 @@ import (
 	"io"
 	"os/exec"
 	"syscall"
+	"time"
 
 	"github.com/creack/pty"
 )
 
-func killCmd(cmd *exec.Cmd) (int, error) {
-	pid := cmd.Process.Pid
+func (e *Engine) killCmd(cmd *exec.Cmd) (pid int, err error) {
+	pid = cmd.Process.Pid
+
+	if e.config.Build.SendInterrupt {
+		// Sending a signal to make it clear to the process that it is time to turn off
+		if err = syscall.Kill(-pid, syscall.SIGINT); err != nil {
+			return
+		}
+
+		time.Sleep(e.config.Build.KillDelay * time.Second)
+	}
+
 	// https://stackoverflow.com/questions/22470193/why-wont-go-kill-a-child-process-correctly
-	err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+	err = syscall.Kill(-pid, syscall.SIGKILL)
+
+	// Wait releases any resources associated with the Process.
+	_, _ = cmd.Process.Wait()
+
 	return pid, err
 }
 

--- a/runner/util_linux.go
+++ b/runner/util_linux.go
@@ -4,19 +4,30 @@ import (
 	"io"
 	"os/exec"
 	"syscall"
+	"time"
 
 	"github.com/creack/pty"
 )
 
-func killCmd(cmd *exec.Cmd) (int, error) {
-	pid := cmd.Process.Pid
+func (e *Engine) killCmd(cmd *exec.Cmd) (pid int, err error) {
+	pid = cmd.Process.Pid
+
+	if e.config.Build.SendInterrupt {
+		// Sending a signal to make it clear to the process that it is time to turn off
+		if err = syscall.Kill(-pid, syscall.SIGINT); err != nil {
+			return
+		}
+
+		time.Sleep(e.config.Build.KillDelay * time.Second)
+	}
+
 	// https://stackoverflow.com/questions/22470193/why-wont-go-kill-a-child-process-correctly
-	err := syscall.Kill(-pid, syscall.SIGKILL)
+	err = syscall.Kill(-pid, syscall.SIGKILL)
 
 	// Wait releases any resources associated with the Process.
 	_, _ = cmd.Process.Wait()
 
-	return pid, err
+	return
 }
 
 func (e *Engine) startCmd(cmd string) (*exec.Cmd, io.ReadCloser, io.ReadCloser, error) {

--- a/runner/util_windows.go
+++ b/runner/util_windows.go
@@ -7,8 +7,9 @@ import (
 	"strings"
 )
 
-func killCmd(cmd *exec.Cmd) (int, error) {
-	pid := cmd.Process.Pid
+func (e *Engine) killCmd(cmd *exec.Cmd) (pid int, err error) {
+	pid = cmd.Process.Pid
+
 	// https://stackoverflow.com/a/44551450
 	kill := exec.Command("TASKKILL", "/T", "/F", "/PID", strconv.Itoa(pid))
 	return pid, kill.Run()


### PR DESCRIPTION
Related #29 

- A `syscall.SIGINT` signal send before `syscall.SIGKILL` with delay, so process can react to closing
- Added `send_interrupt` and `kill_delay` config parameters (defaults: do not use new feature)
- I moved `killCmd` to `Engine`, so i don't need to pass config to func. Hope you don't mind