### PR TITLE
improve on windows

### DIFF
--- a/runner/util.go
+++ b/runner/util.go
@@ -182,7 +182,6 @@ func adaptToVariousPlatforms(c *config) {
 	// Use the unix configuration on Windows
 	if runtime.GOOS == PlatformWindows {
 
-		runName := "start"
 		extName := ".exe"
 		originBin := c.Build.Bin
 		if !strings.HasSuffix(c.Build.Bin, extName) {
@@ -195,9 +194,6 @@ func adaptToVariousPlatforms(c *config) {
 			if !strings.HasSuffix(c.Build.FullBin, extName) {
 
 				c.Build.FullBin += extName
-			}
-			if !strings.HasPrefix(c.Build.FullBin, runName) {
-				c.Build.FullBin = runName + " " + c.Build.FullBin
 			}
 		}
 

--- a/runner/util_windows.go
+++ b/runner/util_windows.go
@@ -21,7 +21,16 @@ func (e *Engine) startCmd(cmd string) (*exec.Cmd, io.ReadCloser, io.ReadCloser, 
 		e.runnerLog("CMD will not recognize non .exe file for execution, path: %s", cmd)
 	}
 
-	c := exec.Command("cmd", "/c", cmd)
+	tmp := strings.Split(cmd, " ")
+	cmdAndArgs := make([]string, 0, len(tmp))
+
+	for _, s := range tmp {
+		if s != "" {
+			cmdAndArgs = append(cmdAndArgs, s)
+		}
+	}
+
+	c := exec.Command(cmdAndArgs[0], cmdAndArgs[1:]...)
 	stderr, err := c.StderrPipe()
 	if err != nil {
 		return nil, nil, nil, err


### PR DESCRIPTION
This PR improve two things on Windows.

The first thing is fail to kill process(configured by "full_bin").
Before this PR, using "start" command (windows native command) for start process.
The "start" command lunch another child process.
air recognize "start" command's PID but not "start command"'s child process PID.
Therefore fail to kill process.

The second thing is improvement "full_bin" configuration on Windows.
Before this PR. using "cmd" command (windows native command) for start process.
As the "cmd" command is native windows command, this command require '\' for path separator.
So We can't use '/' for path separator.
this was improved by not using "cmd", but calling directly "full_bin" configuration's command.