### PR TITLE
fix fail to kill process on windows

### DIFF
--- a/runner/util.go
+++ b/runner/util.go
@@ -197,7 +197,7 @@ func adaptToVariousPlatforms(c *config) {
 				c.Build.FullBin += extName
 			}
 			if !strings.HasPrefix(c.Build.FullBin, runName) {
-				c.Build.FullBin = runName + " " + c.Build.FullBin
+				c.Build.FullBin = runName + " /b " + c.Build.FullBin
 			}
 		}
 


### PR DESCRIPTION
This PR fix that air fail to kill process on Windows.

On windows, using "start" command (windows native command) for start process.
The "start" command lunch another child process.
air recognize "start" command's PID but not "start command"'s child process PID.
Therefore fail to kill process.
So used "/b" option not to create child process.