### PR TITLE
feat: Skip write events for unchanged files

### DIFF
--- a/air_example.toml
+++ b/air_example.toml
@@ -20,6 +20,8 @@ exclude_dir = ["assets", "tmp", "vendor", "frontend/node_modules"]
 include_dir = []
 # Exclude files.
 exclude_file = []
+# Exclude unchanged files.
+exclude_unchanged = true
 # This log file places in your tmp_dir.
 log = "air.log"
 # It's not necessary to trigger build each time file changes if it's too frequent.

--- a/runner/config.go
+++ b/runner/config.go
@@ -28,18 +28,19 @@ type config struct {
 }
 
 type cfgBuild struct {
-	Cmd           string        `toml:"cmd"`
-	Bin           string        `toml:"bin"`
-	FullBin       string        `toml:"full_bin"`
-	Log           string        `toml:"log"`
-	IncludeExt    []string      `toml:"include_ext"`
-	ExcludeDir    []string      `toml:"exclude_dir"`
-	IncludeDir    []string      `toml:"include_dir"`
-	ExcludeFile   []string      `toml:"exclude_file"`
-	Delay         int           `toml:"delay"`
-	StopOnError   bool          `toml:"stop_on_error"`
-	SendInterrupt bool          `toml:"send_interrupt"`
-	KillDelay     time.Duration `toml:"kill_delay"`
+	Cmd              string        `toml:"cmd"`
+	Bin              string        `toml:"bin"`
+	FullBin          string        `toml:"full_bin"`
+	Log              string        `toml:"log"`
+	IncludeExt       []string      `toml:"include_ext"`
+	ExcludeDir       []string      `toml:"exclude_dir"`
+	IncludeDir       []string      `toml:"include_dir"`
+	ExcludeFile      []string      `toml:"exclude_file"`
+	ExcludeUnchanged bool          `toml:"exclude_unchanged"`
+	Delay            int           `toml:"delay"`
+	StopOnError      bool          `toml:"stop_on_error"`
+	SendInterrupt    bool          `toml:"send_interrupt"`
+	KillDelay        time.Duration `toml:"kill_delay"`
 }
 
 type cfgLog struct {

--- a/runner/util_test.go
+++ b/runner/util_test.go
@@ -1,6 +1,7 @@
 package runner
 
 import (
+	"io/ioutil"
 	"os"
 	"testing"
 )
@@ -41,5 +42,85 @@ func TestExpandPathWithHomePath(t *testing.T) {
 	want := home + path[1:]
 	if result != want {
 		t.Errorf("expected '%s' but got '%s'", want, result)
+	}
+}
+
+func TestFileChecksum(t *testing.T) {
+	tests := []struct {
+		name                  string
+		fileContents          []byte
+		expectedChecksum      string
+		expectedChecksumError string
+	}{
+		{
+			name:                  "empty",
+			fileContents:          []byte(``),
+			expectedChecksum:      "",
+			expectedChecksumError: "empty file, forcing rebuild without updating checksum",
+		},
+		{
+			name:                  "simple",
+			fileContents:          []byte(`foo`),
+			expectedChecksum:      "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae",
+			expectedChecksumError: "",
+		},
+		{
+			name:                  "binary",
+			fileContents:          []byte{0xF}, // invalid UTF-8 codepoint
+			expectedChecksum:      "dc0e9c3658a1a3ed1ec94274d8b19925c93e1abb7ddba294923ad9bde30f8cb8",
+			expectedChecksumError: "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			f, err := ioutil.TempFile("", "")
+			if err != nil {
+				t.Fatalf("couldn't create temp file for test: %v", err)
+			}
+
+			defer func() {
+				if err := f.Close(); err != nil {
+					t.Errorf("error closing temp file: %v", err)
+				}
+				if err := os.Remove(f.Name()); err != nil {
+					t.Errorf("error removing temp file: %v", err)
+				}
+			}()
+
+			_, err = f.Write(test.fileContents)
+			if err != nil {
+				t.Fatalf("couldn't write to temp file for test: %v", err)
+			}
+
+			checksum, err := fileChecksum(f.Name())
+			if err != nil && err.Error() != test.expectedChecksumError {
+				t.Errorf("expected '%s' but got '%s'", test.expectedChecksumError, err.Error())
+			}
+
+			if checksum != test.expectedChecksum {
+				t.Errorf("expected '%s' but got '%s'", test.expectedChecksum, checksum)
+			}
+		})
+	}
+}
+
+func TestChecksumMap(t *testing.T) {
+	m := &checksumMap{m: make(map[string]string, 3)}
+
+	if !m.updateFileChecksum("foo.txt", "abcxyz") {
+		t.Errorf("expected no entry for foo.txt, but had one")
+	}
+
+	if m.updateFileChecksum("foo.txt", "abcxyz") {
+		t.Errorf("expected matching entry for foo.txt")
+	}
+
+	if !m.updateFileChecksum("foo.txt", "123456") {
+		t.Errorf("expected matching entry for foo.txt")
+	}
+
+	if !m.updateFileChecksum("bar.txt", "123456") {
+		t.Errorf("expected no entry for bar.txt, but had one")
 	}
 }


### PR DESCRIPTION
Can be enabled with the `[build].exclude_unchanged = true` config option. This is disabled by default.

Editors often save a file even if the contents of the file hasn't changed.
We get the fsnotify event even though there is nothing to be rebuilt in this case.

This PR allows `air` to only rebuild projects if the contents of the files have actually changed.

On startup, we calculate (sha256) checksums of all the watched files, and store them in a cache.
After a file write event, the file contents is hashed to compare it to the previously cached checksum. If the checksums match, the write event is skipped, otherwise the cache is updated and the write event continues.

## Examples

### Running with unchanged file save, then modification:
![Screenshot_20201112_102918](https://user-images.githubusercontent.com/1525809/98928732-0cb73f00-24d2-11eb-8a76-ea5b4b87d8c4.png)

### Startup and file change with debug:
![Screenshot_20201112_102730](https://user-images.githubusercontent.com/1525809/98928767-150f7a00-24d2-11eb-9340-13c6f25f5a7d.png)
![Screenshot_20201112_102833](https://user-images.githubusercontent.com/1525809/98928771-15a81080-24d2-11eb-928b-4c0c4e98bcc7.png)
