### PR TITLE
Fix Relative Path error on Windows

### DIFF
--- a/runner/engine.go
+++ b/runner/engine.go
@@ -388,7 +388,7 @@ func (e *Engine) runBin() error {
 		e.withLock(func() {
 			e.binRunning = false
 		})
-		cmdBinPath := cmdPath(e.config.binPath())
+		cmdBinPath := cmdPath(e.config.rel(e.config.binPath()))
 		if _, err = os.Stat(cmdBinPath); os.IsNotExist(err) {
 			return
 		}


### PR DESCRIPTION
This error was shown when trying to delete old `main.exe` file on Windows:

```console
main.go has changed
building...
failed to remove D:\code\flutter\instachat\server\tmp\main.exe, error: remove D:\code\flutter\instachat\server\D:\code\flutter\instachat\server\tmp\main.exe: The filename, directory name, or volume label syntax is incorrect.
running...
```

This patch fixes that error, locally tested.