### PR TITLE
Add init command to create a .air.toml file to the current directory.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,19 +89,19 @@ The simplest usage is run
 air -c .air.toml
 ```
 
-While I prefer the second way
+You can initialize the `.air.toml` configuration file to the current directory with the default settings running the following command.
 
 ```bash
-# 1. create a new file
-touch .air.toml
+air init
+```
 
-# 2. paste `air_example.toml` into this file, and **modify it** to satisfy your needs.
+After this you can just run the `air` command without additional arguments and it will use the `.air.toml` file for configuration.
 
-# 3. run air with your config. If file name is `.air.toml`, just run `air`.
+```bash
 air
 ```
 
-See the complete [air_example.toml](air_example.toml)
+For modifying the configuration refer to the [air_example.toml](air_example.toml) file.
 
 ### Debug
 

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	_ "embed"
 	"flag"
 	"fmt"
 	"log"
@@ -17,7 +18,18 @@ var (
 	showVersion bool
 )
 
+func helpMessage() {
+	fmt.Fprintf(flag.CommandLine.Output(), "Usage of %s:\n\n", os.Args[0])
+	fmt.Printf("If no command is provided %s will start the runner with the provided flags\n\n", os.Args[0])
+	fmt.Println("Commands:")
+	fmt.Println("  init	creates a .air.toml file with default settings to the current directory\n")
+
+	fmt.Println("Flags:")
+	flag.PrintDefaults()
+}
+
 func init() {
+	flag.Usage = helpMessage
 	flag.StringVar(&cfgPath, "c", "", "config path")
 	flag.BoolVar(&debugMode, "d", false, "debug mode")
 	flag.BoolVar(&showVersion, "v", false, "show version")

--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	_ "embed"
 	"flag"
 	"fmt"
 	"log"

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ func helpMessage() {
 	fmt.Fprintf(flag.CommandLine.Output(), "Usage of %s:\n\n", os.Args[0])
 	fmt.Printf("If no command is provided %s will start the runner with the provided flags\n\n", os.Args[0])
 	fmt.Println("Commands:")
-	fmt.Println("  init	creates a .air.toml file with default settings to the current directory\n")
+	fmt.Print("  init	creates a .air.toml file with default settings to the current directory\n\n")
 
 	fmt.Println("Flags:")
 	flag.PrintDefaults()

--- a/runner/config.go
+++ b/runner/config.go
@@ -80,7 +80,7 @@ func initConfig(path string) (cfg *config, err error) {
 	return cfg, err
 }
 
-func writeConfig() {
+func writeDefaultConfig() {
 	confFiles := []string{dftTOML, dftConf}
 
 	for _, fname := range confFiles {

--- a/runner/config.go
+++ b/runner/config.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"fmt"
 	"io/ioutil"
+	"log"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -77,6 +78,41 @@ func initConfig(path string) (cfg *config, err error) {
 	}
 	err = cfg.preprocess()
 	return cfg, err
+}
+
+func writeConfig() {
+	confFiles := []string{dftTOML, dftConf}
+
+	for _, fname := range confFiles {
+		fstat, err := os.Stat(fname)
+		if err != nil && !os.IsNotExist(err) {
+			log.Fatal("failed to check for existing configuration")
+			return
+		}
+		if err == nil && fstat != nil {
+			log.Fatal("configuration already exists")
+			return
+		}
+	}
+
+	file, err := os.Create(dftTOML)
+	if err != nil {
+		log.Fatalf("failed to create a new confiuration: %+v", err)
+	}
+	defer file.Close()
+
+	config := defaultConfig()
+	configFile, err := toml.Marshal(config)
+	if err != nil {
+		log.Fatalf("failed to marshal the default configuration: %+v", err)
+	}
+
+	_, err = file.Write(configFile)
+	if err != nil {
+		log.Fatalf("failed to write to %s: %+v", dftTOML, err)
+	}
+
+	fmt.Printf("%s file created to the current directory with the default settings\n", dftTOML)
 }
 
 func defaultPathConfig() (*config, error) {

--- a/runner/engine.go
+++ b/runner/engine.go
@@ -71,7 +71,7 @@ func NewEngine(cfgPath string, debugMode bool) (*Engine, error) {
 // Run run run
 func (e *Engine) Run() {
 	if len(os.Args) > 1 && os.Args[1] == "init" {
-		writeConfig()
+		writeDefaultConfig()
 		return
 	}
 

--- a/runner/engine.go
+++ b/runner/engine.go
@@ -70,6 +70,11 @@ func NewEngine(cfgPath string, debugMode bool) (*Engine, error) {
 
 // Run run run
 func (e *Engine) Run() {
+	if len(os.Args) > 0 && os.Args[1] == "init" {
+		writeConfig()
+		return
+	}
+
 	e.mainDebug("CWD: %s", e.config.Root)
 
 	var err error

--- a/runner/engine.go
+++ b/runner/engine.go
@@ -70,7 +70,7 @@ func NewEngine(cfgPath string, debugMode bool) (*Engine, error) {
 
 // Run run run
 func (e *Engine) Run() {
-	if len(os.Args) > 0 && os.Args[1] == "init" {
+	if len(os.Args) > 1 && os.Args[1] == "init" {
 		writeConfig()
 		return
 	}


### PR DESCRIPTION
Calling `air init` will create the .air.toml based on the default configuration to the current directory. 

This will make it easier to start using a custom config in a new project.

Resolves: #153