### PR TITLE
Make TestCode ignored by hot reload

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,4 +8,5 @@ require (
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/imdario/mergo v0.3.12
 	github.com/pelletier/go-toml v1.8.1
+	golang.org/x/sys v0.0.0-20210514084401-e8d321eab015 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,9 @@ github.com/pelletier/go-toml v1.8.1 h1:1Nf83orprkJyknT6h7zbuEGUEjcyVlCxSUGTENmNC
 github.com/pelletier/go-toml v1.8.1/go.mod h1:T2/BmBdy8dvIRq1a/8aqjN41wvWlN4lrapLU/GW4pbc=
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae h1:/WDfKMnPU+m5M4xB+6x4kaepxRw6jWvR5iDRdvjHgy8=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210514084401-e8d321eab015 h1:hZR0X1kPW+nwyJ9xRxqZk1vx5RUObAPBdKVvXPDUH/E=
+golang.org/x/sys v0.0.0-20210514084401-e8d321eab015/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/runner/config.go
+++ b/runner/config.go
@@ -21,12 +21,13 @@ const (
 )
 
 type config struct {
-	Root   string   `toml:"root"`
-	TmpDir string   `toml:"tmp_dir"`
-	Build  cfgBuild `toml:"build"`
-	Color  cfgColor `toml:"color"`
-	Log    cfgLog   `toml:"log"`
-	Misc   cfgMisc  `toml:"misc"`
+	Root        string   `toml:"root"`
+	TmpDir      string   `toml:"tmp_dir"`
+	TestDataDir string   `toml:"testdata_dir"`
+	Build       cfgBuild `toml:"build"`
+	Color       cfgColor `toml:"color"`
+	Log         cfgLog   `toml:"log"`
+	Misc        cfgMisc  `toml:"misc"`
 }
 
 type cfgBuild struct {
@@ -170,7 +171,7 @@ func defaultConfig() config {
 		Bin:         "./tmp/main",
 		Log:         "build-errors.log",
 		IncludeExt:  []string{"go", "tpl", "tmpl", "html"},
-		ExcludeDir:  []string{"assets", "tmp", "vendor"},
+		ExcludeDir:  []string{"assets", "tmp", "vendor", "testdata"},
 		Delay:       1000,
 		StopOnError: true,
 	}
@@ -191,12 +192,13 @@ func defaultConfig() config {
 		CleanOnExit: false,
 	}
 	return config{
-		Root:   ".",
-		TmpDir: "tmp",
-		Build:  build,
-		Color:  color,
-		Log:    log,
-		Misc:   misc,
+		Root:        ".",
+		TmpDir:      "tmp",
+		TestDataDir: "testdata",
+		Build:       build,
+		Color:       color,
+		Log:         log,
+		Misc:        misc,
 	}
 }
 
@@ -236,6 +238,9 @@ func (c *config) preprocess() error {
 	c.Root, err = expandPath(c.Root)
 	if c.TmpDir == "" {
 		c.TmpDir = "tmp"
+	}
+	if c.TestDataDir == "" {
+		c.TestDataDir = "testdata"
 	}
 	if err != nil {
 		return err
@@ -281,6 +286,10 @@ func (c *config) binPath() string {
 
 func (c *config) tmpPath() string {
 	return filepath.Join(c.Root, c.TmpDir)
+}
+
+func (c *config) TestDataPath() string {
+	return filepath.Join(c.Root, c.TestDataDir)
 }
 
 func (c *config) rel(path string) string {

--- a/runner/config.go
+++ b/runner/config.go
@@ -167,13 +167,14 @@ func readConfByName(name string) (*config, error) {
 
 func defaultConfig() config {
 	build := cfgBuild{
-		Cmd:         "go build -o ./tmp/main .",
-		Bin:         "./tmp/main",
-		Log:         "build-errors.log",
-		IncludeExt:  []string{"go", "tpl", "tmpl", "html"},
-		ExcludeDir:  []string{"assets", "tmp", "vendor", "testdata"},
-		Delay:       1000,
-		StopOnError: true,
+		Cmd:          "go build -o ./tmp/main .",
+		Bin:          "./tmp/main",
+		Log:          "build-errors.log",
+		IncludeExt:   []string{"go", "tpl", "tmpl", "html"},
+		ExcludeDir:   []string{"assets", "tmp", "vendor", "testdata"},
+		ExcludeRegex: []string{"_test.go"},
+		Delay:        1000,
+		StopOnError:  true,
 	}
 	if runtime.GOOS == PlatformWindows {
 		build.Bin = `tmp\main.exe`

--- a/runner/config_test.go
+++ b/runner/config_test.go
@@ -18,7 +18,7 @@ func getWindowsConfig() config {
 		Bin:         "./tmp/main",
 		Log:         "build-errors.log",
 		IncludeExt:  []string{"go", "tpl", "tmpl", "html"},
-		ExcludeDir:  []string{"assets", "tmp", "vendor"},
+		ExcludeDir:  []string{"assets", "tmp", "vendor", "testdata"},
 		Delay:       1000,
 		StopOnError: true,
 	}
@@ -28,9 +28,10 @@ func getWindowsConfig() config {
 	}
 
 	return config{
-		Root:   ".",
-		TmpDir: "tmp",
-		Build:  build,
+		Root:        ".",
+		TmpDir:      "tmp",
+		TestDataDir: "testdata",
+		Build:       build,
 	}
 }
 

--- a/runner/config_test.go
+++ b/runner/config_test.go
@@ -14,13 +14,14 @@ const (
 
 func getWindowsConfig() config {
 	build := cfgBuild{
-		Cmd:         "go build -o ./tmp/main .",
-		Bin:         "./tmp/main",
-		Log:         "build-errors.log",
-		IncludeExt:  []string{"go", "tpl", "tmpl", "html"},
-		ExcludeDir:  []string{"assets", "tmp", "vendor", "testdata"},
-		Delay:       1000,
-		StopOnError: true,
+		Cmd:          "go build -o ./tmp/main .",
+		Bin:          "./tmp/main",
+		Log:          "build-errors.log",
+		IncludeExt:   []string{"go", "tpl", "tmpl", "html"},
+		ExcludeDir:   []string{"assets", "tmp", "vendor", "testdata"},
+		ExcludeRegex: []string{"_test.go"},
+		Delay:        1000,
+		StopOnError:  true,
 	}
 	if runtime.GOOS == "windows" {
 		build.Bin = bin

--- a/runner/engine.go
+++ b/runner/engine.go
@@ -112,6 +112,11 @@ func (e *Engine) watching(root string) error {
 			e.watcherLog("!exclude %s", e.config.rel(path))
 			return filepath.SkipDir
 		}
+		// exclude testdata dir
+		if e.isTestDataDir(path) {
+			e.watcherLog("!exclude %s", e.config.rel(path))
+			return filepath.SkipDir
+		}
 		// exclude hidden directories like .git, .idea, etc.
 		if isHiddenDirectory(path) {
 			return filepath.SkipDir
@@ -144,7 +149,7 @@ func (e *Engine) cacheFileChecksums(root string) error {
 		}
 
 		if !info.Mode().IsRegular() {
-			if e.isTmpDir(path) || isHiddenDirectory(path) || e.isExcludeDir(path) {
+			if e.isTmpDir(path) || e.isTestDataDir(path) || isHiddenDirectory(path) || e.isExcludeDir(path) {
 				e.watcherDebug("!exclude checksum %s", e.config.rel(path))
 				return filepath.SkipDir
 			}
@@ -249,6 +254,9 @@ func (e *Engine) watchDir(path string) error {
 
 func (e *Engine) watchNewDir(dir string, removeDir bool) {
 	if e.isTmpDir(dir) {
+		return
+	}
+	if e.isTestDataDir(dir) {
 		return
 	}
 	if isHiddenDirectory(dir) || e.isExcludeDir(dir) {

--- a/runner/util.go
+++ b/runner/util.go
@@ -54,6 +54,10 @@ func (e *Engine) isTmpDir(path string) bool {
 	return path == e.config.tmpPath()
 }
 
+func (e *Engine) isTestDataDir(path string) bool {
+	return path == e.config.TestDataPath()
+}
+
 func isHiddenDirectory(path string) bool {
 	return len(path) > 1 && strings.HasPrefix(filepath.Base(path), ".")
 }


### PR DESCRIPTION
# Purpose of this pull request
- Make test code ignored by hot reload
- and testdata directory is to be ignored an default

# Related things
Issue：#127

# Changed detail
- [x] Make sure testdata is ignored by default
Why：Since golang is designed to put test files in testdata
https://golang.org/cmd/go/#hdr-Test_packages
c9f5750c6798f4ff974cbffc3156fa5f5e761460  
- [x] add ExcludeRegex default value "_test.go"
64084f949353020e8238a69078d1c314e0c8d21c