### PR TITLE
Quote `config.Build.Bin` on the UNIX like OS (including WSL)

### DIFF
--- a/runner/config.go
+++ b/runner/config.go
@@ -255,6 +255,9 @@ func (c *config) preprocess() error {
 	// Fix windows CMD processor
 	// CMD will not recognize relative path like ./tmp/server
 	c.Build.Bin, err = filepath.Abs(c.Build.Bin)
+	if runtime.GOOS != PlatformWindows {
+		c.Build.Bin = fmt.Sprintf("%q", c.Build.Bin)
+	}
 	return err
 }
 


### PR DESCRIPTION
fix #175 

The `config.Build.Bin` is used as a parameter for `/bin/sh -c` ([runner/util_linux.go:32](/cosmtrek/air/blob/master/runner/util_linux.go#L32)).
It must be quoted because it may contains white space or other spacial chars.