### PR TITLE
feat:support command line arguments when user not want use config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,8 @@ Huge thanks to the following supporters. I've always been remembering your kindn
 * Apostolis Anastasiou
 * keita koga
 
+air --tmp_dir test
+
 ## License
 
 [GNU General Public License v3.0](LICENSE)

--- a/README.md
+++ b/README.md
@@ -24,6 +24,15 @@ NOTE: This tool has nothing to do with hot-deploy for production.
 * Allow watching new directories after Air started
 * Better building process
 
+### ✨ beta feature
+Support air config fields as arguments:
+
+if you just want to config build command and run command, you can use like following command without config file:
+
+`air --build.cmd "go build -o bin/api cmd/run.go" --build.bin "./api"`
+
+
+
 ## Installation
 
 ### Prefer install.sh

--- a/README.md
+++ b/README.md
@@ -213,8 +213,6 @@ Huge thanks to the following supporters. I've always been remembering your kindn
 * Apostolis Anastasiou
 * keita koga
 
-air --tmp_dir test
-
 ## License
 
 [GNU General Public License v3.0](LICENSE)

--- a/go.mod
+++ b/go.mod
@@ -7,12 +7,11 @@ require (
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/imdario/mergo v0.3.12
 	github.com/pelletier/go-toml v1.8.1
+	github.com/stretchr/testify v1.7.1
 	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect
 )
 
 require github.com/creack/pty v1.1.11
-
-require github.com/stretchr/testify v1.7.1
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ var (
 	cfgPath     string
 	debugMode   bool
 	showVersion bool
+	cmdArgs     map[string]runner.TomlInfo
 	runArgs     []string
 )
 
@@ -33,6 +34,7 @@ func init() {
 	flag.StringVar(&cfgPath, "c", "", "config path")
 	flag.BoolVar(&debugMode, "d", false, "debug mode")
 	flag.BoolVar(&showVersion, "v", false, "show version")
+	cmdArgs = runner.CreateArgsFlags()
 	flag.Parse()
 }
 
@@ -51,7 +53,9 @@ func main() {
 	if debugMode {
 		fmt.Println("[debug] mode")
 	}
-
+	for k, a := range cmdArgs {
+		fmt.Printf("%v %v \n", k, *a.Value)
+	}
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 

--- a/main.go
+++ b/main.go
@@ -38,7 +38,8 @@ func parseFlag(args []string) {
 	flag.StringVar(&cfgPath, "c", "", "config path")
 	flag.BoolVar(&debugMode, "d", false, "debug mode")
 	flag.BoolVar(&showVersion, "v", false, "show version")
-	cmdArgs = runner.CreateArgsFlags()
+	cmd := flag.CommandLine
+	cmdArgs = runner.CreateArgsFlags(cmd)
 	flag.CommandLine.Parse(args)
 }
 

--- a/main.go
+++ b/main.go
@@ -60,7 +60,13 @@ func main() {
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 
 	var err error
-	r, err := runner.NewEngine(cfgPath, debugMode)
+	cfg, err := runner.InitConfig(cfgPath)
+	if err != nil {
+		log.Fatal(err)
+		return
+	}
+	cfg.WithArgs(cmdArgs)
+	r, err := runner.NewEngineWithConfig(cfg, debugMode)
 	if err != nil {
 		log.Fatal(err)
 		return

--- a/main.go
+++ b/main.go
@@ -39,7 +39,7 @@ func parseFlag(args []string) {
 	flag.BoolVar(&debugMode, "d", false, "debug mode")
 	flag.BoolVar(&showVersion, "v", false, "show version")
 	cmd := flag.CommandLine
-	cmdArgs = runner.CreateArgsFlags(cmd)
+	cmdArgs = runner.ParseConfigFlag(cmd)
 	flag.CommandLine.Parse(args)
 }
 

--- a/main.go
+++ b/main.go
@@ -30,12 +30,16 @@ func helpMessage() {
 }
 
 func init() {
+	parseFlag(os.Args[1:])
+}
+
+func parseFlag(args []string) {
 	flag.Usage = helpMessage
 	flag.StringVar(&cfgPath, "c", "", "config path")
 	flag.BoolVar(&debugMode, "d", false, "debug mode")
 	flag.BoolVar(&showVersion, "v", false, "show version")
 	cmdArgs = runner.CreateArgsFlags()
-	flag.Parse()
+	flag.CommandLine.Parse(args)
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -53,9 +53,6 @@ func main() {
 	if debugMode {
 		fmt.Println("[debug] mode")
 	}
-	for k, a := range cmdArgs {
-		fmt.Printf("%v %v \n", k, *a.Value)
-	}
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 

--- a/runner/cmdarg_test.go
+++ b/runner/cmdarg_test.go
@@ -1,0 +1,1 @@
+package runner

--- a/runner/config.go
+++ b/runner/config.go
@@ -319,12 +319,8 @@ func (c *config) rel(path string) string {
 func (c *config) WithArgs(args map[string]TomlInfo) {
 	for _, value := range args {
 		if value.Value != nil && *value.Value != "" {
-			fmt.Printf("%v",*value.Value)
-
 			v := reflect.ValueOf(c)
-			rfv := setValue2Struct(v, value.fieldPath, *value.Value)
-			newConfig := (rfv.Interface()).(*config)
-			*c = *newConfig
+			setValue2Struct(v, value.fieldPath, *value.Value)
 		}
 	}
 }

--- a/runner/config.go
+++ b/runner/config.go
@@ -21,6 +21,7 @@ const (
 	airWd   = "air_wd"
 )
 
+// Config is the main configuration structure for Air.
 type Config struct {
 	Root        string    `toml:"root"`
 	TmpDir      string    `toml:"tmp_dir"`
@@ -86,6 +87,7 @@ type cfgScreen struct {
 	ClearOnRebuild bool `toml:"clear_on_rebuild"`
 }
 
+// InitConfig initializes the configuration.
 func InitConfig(path string) (cfg *Config, err error) {
 	if path == "" {
 		cfg, err = defaultPathConfig()
@@ -304,7 +306,7 @@ func (c *Config) tmpPath() string {
 	return filepath.Join(c.Root, c.TmpDir)
 }
 
-func (c *Config) TestDataPath() string {
+func (c *Config) testDataPath() string {
 	return filepath.Join(c.Root, c.TestDataDir)
 }
 
@@ -316,6 +318,7 @@ func (c *Config) rel(path string) string {
 	return s
 }
 
+// WithArgs returns a new config with the given arguments added to the configuration.
 func (c *Config) WithArgs(args map[string]TomlInfo) {
 	for _, value := range args {
 		if value.Value != nil && *value.Value != "" {

--- a/runner/config.go
+++ b/runner/config.go
@@ -21,7 +21,7 @@ const (
 	airWd   = "air_wd"
 )
 
-type config struct {
+type Config struct {
 	Root        string    `toml:"root"`
 	TmpDir      string    `toml:"tmp_dir"`
 	TestDataDir string    `toml:"testdata_dir"`
@@ -86,7 +86,7 @@ type cfgScreen struct {
 	ClearOnRebuild bool `toml:"clear_on_rebuild"`
 }
 
-func InitConfig(path string) (cfg *config, err error) {
+func InitConfig(path string) (cfg *Config, err error) {
 	if path == "" {
 		cfg, err = defaultPathConfig()
 		if err != nil {
@@ -141,7 +141,7 @@ func writeDefaultConfig() {
 	fmt.Printf("%s file created to the current directory with the default settings\n", dftTOML)
 }
 
-func defaultPathConfig() (*config, error) {
+func defaultPathConfig() (*Config, error) {
 	// when path is blank, first find `.air.toml`, `.air.conf` in `air_wd` and current working directory, if not found, use defaults
 	for _, name := range []string{dftTOML, dftConf} {
 		cfg, err := readConfByName(name)
@@ -157,7 +157,7 @@ func defaultPathConfig() (*config, error) {
 	return &dftCfg, nil
 }
 
-func readConfByName(name string) (*config, error) {
+func readConfByName(name string) (*Config, error) {
 	var path string
 	if wd := os.Getenv(airWd); wd != "" {
 		path = filepath.Join(wd, name)
@@ -172,7 +172,7 @@ func readConfByName(name string) (*config, error) {
 	return cfg, err
 }
 
-func defaultConfig() config {
+func defaultConfig() Config {
 	build := cfgBuild{
 		Cmd:          "go build -o ./tmp/main .",
 		Bin:          "./tmp/main",
@@ -202,7 +202,7 @@ func defaultConfig() config {
 	misc := cfgMisc{
 		CleanOnExit: false,
 	}
-	return config{
+	return Config{
 		Root:        ".",
 		TmpDir:      "tmp",
 		TestDataDir: "testdata",
@@ -213,13 +213,13 @@ func defaultConfig() config {
 	}
 }
 
-func readConfig(path string) (*config, error) {
+func readConfig(path string) (*Config, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
 
-	cfg := new(config)
+	cfg := new(Config)
 	if err = toml.Unmarshal(data, cfg); err != nil {
 		return nil, err
 	}
@@ -227,7 +227,7 @@ func readConfig(path string) (*config, error) {
 	return cfg, nil
 }
 
-func readConfigOrDefault(path string) (*config, error) {
+func readConfigOrDefault(path string) (*Config, error) {
 	dftCfg := defaultConfig()
 	cfg, err := readConfig(path)
 	if err != nil {
@@ -237,7 +237,7 @@ func readConfigOrDefault(path string) (*config, error) {
 	return cfg, nil
 }
 
-func (c *config) preprocess() error {
+func (c *Config) preprocess() error {
 	var err error
 	cwd := os.Getenv(airWd)
 	if cwd != "" {
@@ -279,7 +279,7 @@ func (c *config) preprocess() error {
 	return err
 }
 
-func (c *config) colorInfo() map[string]string {
+func (c *Config) colorInfo() map[string]string {
 	return map[string]string{
 		"main":    c.Color.Main,
 		"build":   c.Color.Build,
@@ -288,27 +288,27 @@ func (c *config) colorInfo() map[string]string {
 	}
 }
 
-func (c *config) buildLogPath() string {
+func (c *Config) buildLogPath() string {
 	return filepath.Join(c.tmpPath(), c.Build.Log)
 }
 
-func (c *config) buildDelay() time.Duration {
+func (c *Config) buildDelay() time.Duration {
 	return time.Duration(c.Build.Delay) * time.Millisecond
 }
 
-func (c *config) binPath() string {
+func (c *Config) binPath() string {
 	return filepath.Join(c.Root, c.Build.Bin)
 }
 
-func (c *config) tmpPath() string {
+func (c *Config) tmpPath() string {
 	return filepath.Join(c.Root, c.TmpDir)
 }
 
-func (c *config) TestDataPath() string {
+func (c *Config) TestDataPath() string {
 	return filepath.Join(c.Root, c.TestDataDir)
 }
 
-func (c *config) rel(path string) string {
+func (c *Config) rel(path string) string {
 	s, err := filepath.Rel(c.Root, path)
 	if err != nil {
 		return ""
@@ -316,7 +316,7 @@ func (c *config) rel(path string) string {
 	return s
 }
 
-func (c *config) WithArgs(args map[string]TomlInfo) {
+func (c *Config) WithArgs(args map[string]TomlInfo) {
 	for _, value := range args {
 		if value.Value != nil && *value.Value != "" {
 			v := reflect.ValueOf(c)

--- a/runner/config.go
+++ b/runner/config.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"runtime"
 	"time"
@@ -85,7 +86,7 @@ type cfgScreen struct {
 	ClearOnRebuild bool `toml:"clear_on_rebuild"`
 }
 
-func initConfig(path string) (cfg *config, err error) {
+func InitConfig(path string) (cfg *config, err error) {
 	if path == "" {
 		cfg, err = defaultPathConfig()
 		if err != nil {
@@ -313,4 +314,17 @@ func (c *config) rel(path string) string {
 		return ""
 	}
 	return s
+}
+
+func (c *config) WithArgs(args map[string]TomlInfo) {
+	for _, value := range args {
+		if value.Value != nil && *value.Value != "" {
+			fmt.Printf("%v",*value.Value)
+
+			v := reflect.ValueOf(c)
+			rfv := setValue2Struct(v, value.fieldPath, *value.Value)
+			newConfig := (rfv.Interface()).(*config)
+			*c = *newConfig
+		}
+	}
 }

--- a/runner/config_test.go
+++ b/runner/config_test.go
@@ -12,7 +12,7 @@ const (
 	cmd = "go build -o ./tmp/main ."
 )
 
-func getWindowsConfig() config {
+func getWindowsConfig() Config {
 	build := cfgBuild{
 		Cmd:          "go build -o ./tmp/main .",
 		Bin:          "./tmp/main",
@@ -28,7 +28,7 @@ func getWindowsConfig() config {
 		build.Cmd = cmd
 	}
 
-	return config{
+	return Config{
 		Root:        ".",
 		TmpDir:      "tmp",
 		TestDataDir: "testdata",
@@ -110,7 +110,7 @@ func TestReadConfByName(t *testing.T) {
 	_ = os.Unsetenv(airWd)
 	config, _ := readConfByName(dftTOML)
 	if config != nil {
-		t.Fatalf("expect config is nil,but get a not nil config")
+		t.Fatalf("expect Config is nil,but get a not nil Config")
 	}
 }
 

--- a/runner/engine.go
+++ b/runner/engine.go
@@ -67,7 +67,7 @@ func NewEngineWithConfig(cfg *config, debugMode bool) (*Engine, error) {
 // NewEngine ...
 func NewEngine(cfgPath string, debugMode bool) (*Engine, error) {
 	var err error
-	cfg, err := initConfig(cfgPath)
+	cfg, err := InitConfig(cfgPath)
 	if err != nil {
 		return nil, err
 	}

--- a/runner/engine.go
+++ b/runner/engine.go
@@ -37,14 +37,8 @@ type Engine struct {
 	ll sync.Mutex // lock for logger
 }
 
-// NewEngine ...
-func NewEngine(cfgPath string, debugMode bool) (*Engine, error) {
-	var err error
-	cfg, err := initConfig(cfgPath)
-	if err != nil {
-		return nil, err
-	}
-
+// NewEngineWithConfig ...
+func NewEngineWithConfig(cfg *config, debugMode bool) (*Engine, error) {
 	logger := newLogger(cfg)
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
@@ -68,6 +62,16 @@ func NewEngine(cfgPath string, debugMode bool) (*Engine, error) {
 	}
 
 	return &e, nil
+}
+
+// NewEngine ...
+func NewEngine(cfgPath string, debugMode bool) (*Engine, error) {
+	var err error
+	cfg, err := initConfig(cfgPath)
+	if err != nil {
+		return nil, err
+	}
+	return NewEngineWithConfig(cfg, debugMode)
 }
 
 // Run run run

--- a/runner/engine.go
+++ b/runner/engine.go
@@ -15,7 +15,7 @@ import (
 
 // Engine ...
 type Engine struct {
-	config    *config
+	config    *Config
 	logger    *logger
 	watcher   *fsnotify.Watcher
 	debugMode bool
@@ -38,7 +38,7 @@ type Engine struct {
 }
 
 // NewEngineWithConfig ...
-func NewEngineWithConfig(cfg *config, debugMode bool) (*Engine, error) {
+func NewEngineWithConfig(cfg *Config, debugMode bool) (*Engine, error) {
 	logger := newLogger(cfg)
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {

--- a/runner/engine_test.go
+++ b/runner/engine_test.go
@@ -25,7 +25,7 @@ func TestNewEngine(t *testing.T) {
 		t.Fatal("logger should not be nil")
 	}
 	if engine.config == nil {
-		t.Fatal("config should not be nil")
+		t.Fatal("Config should not be nil")
 	}
 	if engine.watcher == nil {
 		t.Fatal("watcher should not be nil")
@@ -200,7 +200,7 @@ func TestCtrlCWhenHaveKillDelay(t *testing.T) {
 	// fix https://github.com/cosmtrek/air/issues/278
 	// generate a random port
 	data := []byte("[build]\n  kill_delay = \"2s\"")
-	c := config{}
+	c := Config{}
 	if err := toml.Unmarshal(data, &c); err != nil {
 		t.Fatalf("Should not be fail: %s.", err)
 	}

--- a/runner/flag.go
+++ b/runner/flag.go
@@ -1,0 +1,14 @@
+package runner
+
+import (
+	"flag"
+)
+
+func CreateArgsFlags() map[string]TomlInfo {
+	c := config{}
+	m := CreateStructureFieldTagMap(c)
+	for k, v := range m {
+		flag.StringVar(v.Value, k, "", "")
+	}
+	return m
+}

--- a/runner/flag.go
+++ b/runner/flag.go
@@ -4,11 +4,11 @@ import (
 	"flag"
 )
 
-func CreateArgsFlags() map[string]TomlInfo {
+func CreateArgsFlags(f *flag.FlagSet) map[string]TomlInfo {
 	c := config{}
-	m := CreateStructureFieldTagMap(c)
+	m := flatConfig(c)
 	for k, v := range m {
-		flag.StringVar(v.Value, k, "", "")
+		f.StringVar(v.Value, k, "", "")
 	}
 	return m
 }

--- a/runner/flag.go
+++ b/runner/flag.go
@@ -4,8 +4,9 @@ import (
 	"flag"
 )
 
-func CreateArgsFlags(f *flag.FlagSet) map[string]TomlInfo {
-	c := config{}
+// ParseConfigFlag parse toml information for flag
+func ParseConfigFlag(f *flag.FlagSet) map[string]TomlInfo {
+	c := Config{}
 	m := flatConfig(c)
 	for k, v := range m {
 		f.StringVar(v.Value, k, "", "")

--- a/runner/flag_test.go
+++ b/runner/flag_test.go
@@ -3,6 +3,7 @@ package runner
 import (
 	"flag"
 	"log"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -100,6 +101,8 @@ func TestConfigRuntimeArgs(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			os.Chdir(dir)
 			flag := flag.NewFlagSet(t.Name(), flag.ExitOnError)
 			cmdArgs := CreateArgsFlags(flag)
 			flag.Parse(tc.args)

--- a/runner/flag_test.go
+++ b/runner/flag_test.go
@@ -2,6 +2,7 @@ package runner
 
 import (
 	"flag"
+	"log"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -47,6 +48,68 @@ func TestFlag(t *testing.T) {
 			cmdArgs := CreateArgsFlags(flag)
 			flag.Parse(tc.args)
 			assert.Equal(t, tc.expected, *cmdArgs[tc.key].Value)
+		})
+	}
+}
+
+func TestConfigRuntimeArgs(t *testing.T) {
+	// table driven tests
+	type testCase struct {
+		name     string
+		args     []string
+		expected string
+		key      string
+		check    func(t *testing.T, conf *config)
+	}
+	testCases := []testCase{
+		{
+			name:     "test1",
+			args:     []string{"--build.cmd", "go build -o ./tmp/main ."},
+			expected: "go build -o ./tmp/main .",
+			key:      "build.cmd",
+			check: func(t *testing.T, conf *config) {
+				assert.Equal(t, "go build -o ./tmp/main .", conf.Build.Cmd)
+			},
+		},
+		{
+			name:     "tmp dir test",
+			args:     []string{"--tmp_dir", "test"},
+			expected: "test",
+			key:      "tmp_dir",
+			check: func(t *testing.T, conf *config) {
+				assert.Equal(t, "test", conf.TmpDir)
+			},
+		},
+		{
+			name:     "check bool",
+			args:     []string{"--build.exclude_unchanged", "true"},
+			expected: "true",
+			key:      "build.exclude_unchanged",
+			check: func(t *testing.T, conf *config) {
+				assert.Equal(t, true, conf.Build.ExcludeUnchanged)
+			},
+		},
+		{
+			name:     "check exclude_regex",
+			args:     []string{"--build.exclude_regex", `["_test.go"]`},
+			expected: `["_test.go"]`,
+			check: func(t *testing.T, conf *config) {
+				assert.Equal(t, []string{"_test.go"}, conf.Build.ExcludeRegex)
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			flag := flag.NewFlagSet(t.Name(), flag.ExitOnError)
+			cmdArgs := CreateArgsFlags(flag)
+			flag.Parse(tc.args)
+			cfg, err := InitConfig("")
+			if err != nil {
+				log.Fatal(err)
+				return
+			}
+			cfg.WithArgs(cmdArgs)
+			tc.check(t, cfg)
 		})
 	}
 }

--- a/runner/flag_test.go
+++ b/runner/flag_test.go
@@ -53,7 +53,7 @@ func TestFlag(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			flag := flag.NewFlagSet(t.Name(), flag.ExitOnError)
-			cmdArgs := CreateArgsFlags(flag)
+			cmdArgs := ParseConfigFlag(flag)
 			flag.Parse(tc.args)
 			assert.Equal(t, tc.expected, *cmdArgs[tc.key].Value)
 		})
@@ -66,14 +66,14 @@ func TestConfigRuntimeArgs(t *testing.T) {
 		name  string
 		args  []string
 		key   string
-		check func(t *testing.T, conf *config)
+		check func(t *testing.T, conf *Config)
 	}
 	testCases := []testCase{
 		{
 			name: "test1",
 			args: []string{"--build.cmd", "go build -o ./tmp/main ."},
 			key:  "build.cmd",
-			check: func(t *testing.T, conf *config) {
+			check: func(t *testing.T, conf *Config) {
 				assert.Equal(t, "go build -o ./tmp/main .", conf.Build.Cmd)
 			},
 		},
@@ -81,7 +81,7 @@ func TestConfigRuntimeArgs(t *testing.T) {
 			name: "tmp dir test",
 			args: []string{"--tmp_dir", "test"},
 			key:  "tmp_dir",
-			check: func(t *testing.T, conf *config) {
+			check: func(t *testing.T, conf *Config) {
 				assert.Equal(t, "test", conf.TmpDir)
 			},
 		},
@@ -89,7 +89,7 @@ func TestConfigRuntimeArgs(t *testing.T) {
 			name: "check int64",
 			args: []string{"--build.kill_delay", "1000"},
 			key:  "build.kill_delay",
-			check: func(t *testing.T, conf *config) {
+			check: func(t *testing.T, conf *Config) {
 				assert.Equal(t, time.Duration(1000), conf.Build.KillDelay)
 			},
 		},
@@ -97,14 +97,14 @@ func TestConfigRuntimeArgs(t *testing.T) {
 			name: "check bool",
 			args: []string{"--build.exclude_unchanged", "true"},
 			key:  "build.exclude_unchanged",
-			check: func(t *testing.T, conf *config) {
+			check: func(t *testing.T, conf *Config) {
 				assert.Equal(t, true, conf.Build.ExcludeUnchanged)
 			},
 		},
 		{
 			name: "check exclude_regex",
 			args: []string{"--build.exclude_regex", `["_test.go"]`},
-			check: func(t *testing.T, conf *config) {
+			check: func(t *testing.T, conf *Config) {
 				assert.Equal(t, []string{"_test.go"}, conf.Build.ExcludeRegex)
 			},
 		},
@@ -114,7 +114,7 @@ func TestConfigRuntimeArgs(t *testing.T) {
 			dir := t.TempDir()
 			os.Chdir(dir)
 			flag := flag.NewFlagSet(t.Name(), flag.ExitOnError)
-			cmdArgs := CreateArgsFlags(flag)
+			cmdArgs := ParseConfigFlag(flag)
 			flag.Parse(tc.args)
 			cfg, err := InitConfig("")
 			if err != nil {

--- a/runner/flag_test.go
+++ b/runner/flag_test.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -37,6 +38,12 @@ func TestFlag(t *testing.T) {
 			key:      "build.exclude_unchanged",
 		},
 		{
+			name:     "check int",
+			args:     []string{"--build.kill_delay", "1000"},
+			expected: "1000",
+			key:      "build.kill_delay",
+		},
+		{
 			name:     "check exclude_regex",
 			args:     []string{"--build.exclude_regex", `["_test.go"]`},
 			expected: `["_test.go"]`,
@@ -56,44 +63,47 @@ func TestFlag(t *testing.T) {
 func TestConfigRuntimeArgs(t *testing.T) {
 	// table driven tests
 	type testCase struct {
-		name     string
-		args     []string
-		expected string
-		key      string
-		check    func(t *testing.T, conf *config)
+		name  string
+		args  []string
+		key   string
+		check func(t *testing.T, conf *config)
 	}
 	testCases := []testCase{
 		{
-			name:     "test1",
-			args:     []string{"--build.cmd", "go build -o ./tmp/main ."},
-			expected: "go build -o ./tmp/main .",
-			key:      "build.cmd",
+			name: "test1",
+			args: []string{"--build.cmd", "go build -o ./tmp/main ."},
+			key:  "build.cmd",
 			check: func(t *testing.T, conf *config) {
 				assert.Equal(t, "go build -o ./tmp/main .", conf.Build.Cmd)
 			},
 		},
 		{
-			name:     "tmp dir test",
-			args:     []string{"--tmp_dir", "test"},
-			expected: "test",
-			key:      "tmp_dir",
+			name: "tmp dir test",
+			args: []string{"--tmp_dir", "test"},
+			key:  "tmp_dir",
 			check: func(t *testing.T, conf *config) {
 				assert.Equal(t, "test", conf.TmpDir)
 			},
 		},
 		{
-			name:     "check bool",
-			args:     []string{"--build.exclude_unchanged", "true"},
-			expected: "true",
-			key:      "build.exclude_unchanged",
+			name: "check int64",
+			args: []string{"--build.kill_delay", "1000"},
+			key:  "build.kill_delay",
+			check: func(t *testing.T, conf *config) {
+				assert.Equal(t, time.Duration(1000), conf.Build.KillDelay)
+			},
+		},
+		{
+			name: "check bool",
+			args: []string{"--build.exclude_unchanged", "true"},
+			key:  "build.exclude_unchanged",
 			check: func(t *testing.T, conf *config) {
 				assert.Equal(t, true, conf.Build.ExcludeUnchanged)
 			},
 		},
 		{
-			name:     "check exclude_regex",
-			args:     []string{"--build.exclude_regex", `["_test.go"]`},
-			expected: `["_test.go"]`,
+			name: "check exclude_regex",
+			args: []string{"--build.exclude_regex", `["_test.go"]`},
 			check: func(t *testing.T, conf *config) {
 				assert.Equal(t, []string{"_test.go"}, conf.Build.ExcludeRegex)
 			},

--- a/runner/flag_test.go
+++ b/runner/flag_test.go
@@ -1,0 +1,52 @@
+package runner
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFlag(t *testing.T) {
+	// table driven tests
+	type testCase struct {
+		name     string
+		args     []string
+		expected string
+		key      string
+	}
+	testCases := []testCase{
+		{
+			name:     "test1",
+			args:     []string{"--build.cmd", "go build -o ./tmp/main ."},
+			expected: "go build -o ./tmp/main .",
+			key:      "build.cmd",
+		},
+		{
+			name:     "tmp dir test",
+			args:     []string{"--tmp_dir", "test"},
+			expected: "test",
+			key:      "tmp_dir",
+		},
+		{
+			name:     "check bool",
+			args:     []string{"--build.exclude_unchanged", "true"},
+			expected: "true",
+			key:      "build.exclude_unchanged",
+		},
+		{
+			name:     "check exclude_regex",
+			args:     []string{"--build.exclude_regex", `["_test.go"]`},
+			expected: `["_test.go"]`,
+			key:      "build.exclude_regex",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			flag := flag.NewFlagSet(t.Name(), flag.ExitOnError)
+			cmdArgs := CreateArgsFlags(flag)
+			flag.Parse(tc.args)
+			assert.Equal(t, tc.expected, *cmdArgs[tc.key].Value)
+		})
+	}
+}

--- a/runner/logger.go
+++ b/runner/logger.go
@@ -26,12 +26,12 @@ var (
 type logFunc func(string, ...interface{})
 
 type logger struct {
-	config  *config
+	config  *Config
 	colors  map[string]string
 	loggers map[string]logFunc
 }
 
-func newLogger(cfg *config) *logger {
+func newLogger(cfg *Config) *logger {
 	if cfg == nil {
 		return nil
 	}

--- a/runner/util.go
+++ b/runner/util.go
@@ -273,10 +273,10 @@ type TomlInfo struct {
 	Value     *string
 }
 
-func setValue2Struct(v reflect.Value, fieldName string, value string) *reflect.Value {
+func setValue2Struct(v reflect.Value, fieldName string, value string) {
 	index := strings.Index(fieldName, ".")
 	if index == -1 && len(fieldName) == 0 {
-		return nil
+		return
 	}
 	fields := strings.Split(fieldName, ".")
 	var addressableVal reflect.Value
@@ -290,14 +290,11 @@ func setValue2Struct(v reflect.Value, fieldName string, value string) *reflect.V
 		field := addressableVal.FieldByName(fieldName)
 		field.SetString(value)
 	} else if len(fields) == 0 {
-		return nil
 	} else {
 		field := addressableVal.FieldByName(fields[0])
 		s2 := fieldName[index+1:]
-		value := setValue2Struct(field, s2, value)
-		field.Set(*value)
+		setValue2Struct(field, s2, value)
 	}
-	return &v
 }
 
 // CreateStructureFieldTagMap ...
@@ -307,7 +304,6 @@ func CreateStructureFieldTagMap(stut interface{}) map[string]TomlInfo {
 	setTage2Map("", t, m, "")
 	return m
 }
-
 
 func setTage2Map(root string, t reflect.Type, m map[string]TomlInfo, fieldPath string) {
 	for i := 0; i < t.NumField(); i++ {

--- a/runner/util.go
+++ b/runner/util.go
@@ -290,6 +290,7 @@ func setValue2Struct(v reflect.Value, fieldName string, value string) {
 		field := addressableVal.FieldByName(fieldName)
 		field.SetString(value)
 	} else if len(fields) == 0 {
+		return
 	} else {
 		field := addressableVal.FieldByName(fields[0])
 		s2 := fieldName[index+1:]

--- a/runner/util.go
+++ b/runner/util.go
@@ -298,6 +298,9 @@ func setValue2Struct(v reflect.Value, fieldName string, value string) {
 			if field.Len() == 0 {
 				field.Set(reflect.Append(field, reflect.ValueOf(value)))
 			}
+		case reflect.Int64:
+			i, _ := strconv.ParseInt(value, 10, 64)
+			field.SetInt(i)
 		case reflect.Int:
 			i, _ := strconv.Atoi(value)
 			field.SetInt(int64(i))

--- a/runner/util.go
+++ b/runner/util.go
@@ -57,7 +57,7 @@ func (e *Engine) isTmpDir(path string) bool {
 }
 
 func (e *Engine) isTestDataDir(path string) bool {
-	return path == e.config.TestDataPath()
+	return path == e.config.testDataPath()
 }
 
 func isHiddenDirectory(path string) bool {

--- a/runner/util.go
+++ b/runner/util.go
@@ -202,7 +202,7 @@ func cmdPath(path string) string {
 	return strings.Split(path, " ")[0]
 }
 
-func adaptToVariousPlatforms(c *config) {
+func adaptToVariousPlatforms(c *Config) {
 	// Fix the default configuration is not used in Windows
 	// Use the unix configuration on Windows
 	if runtime.GOOS == PlatformWindows {
@@ -269,6 +269,7 @@ func (a *checksumMap) updateFileChecksum(filename, newChecksum string) (ok bool)
 	return false
 }
 
+// TomlInfo is a struct for toml config file
 type TomlInfo struct {
 	fieldPath string
 	field     reflect.StructField
@@ -283,7 +284,7 @@ func setValue2Struct(v reflect.Value, fieldName string, value string) {
 	fields := strings.Split(fieldName, ".")
 	var addressableVal reflect.Value
 	switch v.Type().String() {
-	case "*runner.config":
+	case "*runner.Config":
 		addressableVal = v.Elem()
 	default:
 		addressableVal = v

--- a/runner/util.go
+++ b/runner/util.go
@@ -208,7 +208,7 @@ func adaptToVariousPlatforms(c *config) {
 		runName := "start"
 		extName := ".exe"
 		originBin := c.Build.Bin
-		
+
 		if 0 < len(c.Build.FullBin) {
 
 			if !strings.HasSuffix(c.Build.FullBin, extName) {
@@ -298,8 +298,8 @@ func setValue2Struct(v reflect.Value, fieldName string, value string) {
 	}
 }
 
-// CreateStructureFieldTagMap ...
-func CreateStructureFieldTagMap(stut interface{}) map[string]TomlInfo {
+// flatConfig ...
+func flatConfig(stut interface{}) map[string]TomlInfo {
 	m := make(map[string]TomlInfo)
 	t := reflect.TypeOf(stut)
 	setTage2Map("", t, m, "")

--- a/runner/util_test.go
+++ b/runner/util_test.go
@@ -230,3 +230,8 @@ func Test_killCmd_SendInterrupt_false(t *testing.T) {
 		}
 	}
 }
+
+func TestGetStructureFieldTagMap(t *testing.T) {
+	c := config{}
+	CreateStructureFieldTagMap(c)
+}

--- a/runner/util_test.go
+++ b/runner/util_test.go
@@ -246,24 +246,14 @@ func TestGetStructureFieldTagMap(t *testing.T) {
 func TestSetStructValue(t *testing.T) {
 	c := config{}
 	v := reflect.ValueOf(&c)
-	c1 := setValue2Struct(v, "TmpDir", "asdasd")
-	c2 := (c1.Interface()).(*config)
-	assert.Equal(t, "asdasd", c2.TmpDir)
+	setValue2Struct(v, "TmpDir", "asdasd")
+	assert.Equal(t, "asdasd", c.TmpDir)
 }
 
 func TestNestStructValue(t *testing.T) {
 	c := config{}
 	v := reflect.ValueOf(&c)
-	c1 := setValue2Struct(v, "Build.Cmd", "asdasd")
-	c2 := (c1.Interface()).(*config)
-	assert.Equal(t, "asdasd", c2.Build.Cmd)
+	setValue2Struct(v, "Build.Cmd", "asdasd")
+	assert.Equal(t, "asdasd", c.Build.Cmd)
 }
 
-func TestStruct(t *testing.T) {
-	c := &config{}
-	v := reflect.ValueOf(c)
-	config := setValue2Struct(v, "", "asdasd")
-	if config != nil {
-		t.Fatal()
-	}
-}

--- a/runner/util_test.go
+++ b/runner/util_test.go
@@ -138,7 +138,7 @@ func TestChecksumMap(t *testing.T) {
 }
 
 func TestAdaptToVariousPlatforms(t *testing.T) {
-	config := &config{
+	config := &Config{
 		Build: cfgBuild{
 			Bin: "tmp\\main.exe  -dev",
 		},
@@ -151,7 +151,7 @@ func TestAdaptToVariousPlatforms(t *testing.T) {
 
 func Test_killCmd_no_process(t *testing.T) {
 	e := Engine{
-		config: &config{
+		config: &Config{
 			Build: cfgBuild{
 				SendInterrupt: false,
 			},
@@ -184,7 +184,7 @@ func Test_killCmd_SendInterrupt_false(t *testing.T) {
 	os.Remove("pid")
 	defer os.Remove("pid")
 	e := Engine{
-		config: &config{
+		config: &Config{
 			Build: cfgBuild{
 				SendInterrupt: false,
 			},
@@ -236,7 +236,7 @@ func Test_killCmd_SendInterrupt_false(t *testing.T) {
 }
 
 func TestGetStructureFieldTagMap(t *testing.T) {
-	c := config{}
+	c := Config{}
 	tagMap := flatConfig(c)
 	for _, i2 := range tagMap {
 		fmt.Printf("%v\n", i2.fieldPath)
@@ -244,14 +244,14 @@ func TestGetStructureFieldTagMap(t *testing.T) {
 }
 
 func TestSetStructValue(t *testing.T) {
-	c := config{}
+	c := Config{}
 	v := reflect.ValueOf(&c)
 	setValue2Struct(v, "TmpDir", "asdasd")
 	assert.Equal(t, "asdasd", c.TmpDir)
 }
 
 func TestNestStructValue(t *testing.T) {
-	c := config{}
+	c := Config{}
 	v := reflect.ValueOf(&c)
 	setValue2Struct(v, "Build.Cmd", "asdasd")
 	assert.Equal(t, "asdasd", c.Build.Cmd)

--- a/runner/util_test.go
+++ b/runner/util_test.go
@@ -237,7 +237,7 @@ func Test_killCmd_SendInterrupt_false(t *testing.T) {
 
 func TestGetStructureFieldTagMap(t *testing.T) {
 	c := config{}
-	tagMap := CreateStructureFieldTagMap(c)
+	tagMap := flatConfig(c)
 	for _, i2 := range tagMap {
 		fmt.Printf("%v\n", i2.fieldPath)
 	}
@@ -256,4 +256,3 @@ func TestNestStructValue(t *testing.T) {
 	setValue2Struct(v, "Build.Cmd", "asdasd")
 	assert.Equal(t, "asdasd", c.Build.Cmd)
 }
-

--- a/runner/util_test.go
+++ b/runner/util_test.go
@@ -2,16 +2,20 @@ package runner
 
 import (
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strconv"
 	"strings"
 	"syscall"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestIsDirRootPath(t *testing.T) {
@@ -233,5 +237,33 @@ func Test_killCmd_SendInterrupt_false(t *testing.T) {
 
 func TestGetStructureFieldTagMap(t *testing.T) {
 	c := config{}
-	CreateStructureFieldTagMap(c)
+	tagMap := CreateStructureFieldTagMap(c)
+	for _, i2 := range tagMap {
+		fmt.Printf("%v\n", i2.fieldPath)
+	}
+}
+
+func TestSetStructValue(t *testing.T) {
+	c := config{}
+	v := reflect.ValueOf(&c)
+	c1 := setValue2Struct(v, "TmpDir", "asdasd")
+	c2 := (c1.Interface()).(*config)
+	assert.Equal(t, "asdasd", c2.TmpDir)
+}
+
+func TestNestStructValue(t *testing.T) {
+	c := config{}
+	v := reflect.ValueOf(&c)
+	c1 := setValue2Struct(v, "Build.Cmd", "asdasd")
+	c2 := (c1.Interface()).(*config)
+	assert.Equal(t, "asdasd", c2.Build.Cmd)
+}
+
+func TestStruct(t *testing.T) {
+	c := &config{}
+	v := reflect.ValueOf(c)
+	config := setValue2Struct(v, "", "asdasd")
+	if config != nil {
+		t.Fatal()
+	}
 }


### PR DESCRIPTION
Support air config fields as arguments:

if you just want to config build command and run command, you can use like following command without config file:

`air --build.cmd "go build -o bin/api cmd/run.go" --build.bin "./api"`

in toml config define: 

```toml
[build]
full_bin = "APP_ENV=dev APP_USER=air ./tmp/main"
```

It will be `air --build.full_bin "APP_ENV=dev APP_USER=air ./tmp/main"`

for slice fields:

```toml
[build]
exclude_regex = ["_test.go"]
```
it will be `air --build.exclude_regex ["_test.go"]`

and so on...
