### PR TITLE
Exclude node_modules by default

### DIFF
--- a/runner/config.go
+++ b/runner/config.go
@@ -171,7 +171,7 @@ func defaultConfig() config {
 		Bin:          "./tmp/main",
 		Log:          "build-errors.log",
 		IncludeExt:   []string{"go", "tpl", "tmpl", "html"},
-		ExcludeDir:   []string{"assets", "tmp", "vendor", "testdata"},
+		ExcludeDir:   []string{"assets", "tmp", "vendor", "node_modules", "testdata"},
 		ExcludeRegex: []string{"_test.go"},
 		Delay:        1000,
 		StopOnError:  true,


### PR DESCRIPTION
Nobody wants having to deal with `node_modules`, and I think it's a nice default.

They are the only reason I used `air init`.

PS: Air is a really nice CLI, I use it in all my projects ! If you do not agree with this PR, no problem, you can refuse it.