### PR TITLE
Allow linux/arm64 platforms it work with docker over m1

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -66,6 +66,7 @@ get_binaries() {
     darwin/arm64) BINARIES="air" ;;
     linux/386) BINARIES="air" ;;
     linux/amd64) BINARIES="air" ;;
+    linux/arm64) BINARIES="air" ;;
     windows/386) BINARIES="air" ;;
     windows/amd64) BINARIES="air" ;;
     *)


### PR DESCRIPTION
When Docker runs over darwin/arm64 usually convert the platform to linux/arm64 just added this platform to allow to run over docker 