### PR TITLE
Bugfix, get "no such process" with the process id negated

### DIFF
--- a/runner/util_darwin.go
+++ b/runner/util_darwin.go
@@ -13,7 +13,7 @@ func (e *Engine) killCmd(cmd *exec.Cmd) (pid int, err error) {
 
 	if e.config.Build.SendInterrupt {
 		// Sending a signal to make it clear to the process that it is time to turn off
-		if err = syscall.Kill(-pid, syscall.SIGINT); err != nil {
+		if err = syscall.Kill(pid, syscall.SIGINT); err != nil {
 			e.mainDebug("trying to send signal failed %v", err)
 			return
 		}


### PR DESCRIPTION
After removing the `-`, my process can receive the SIGINT correctly.