### PR TITLE
io/ioutil package is deprecated

### DIFF
--- a/runner/config.go
+++ b/runner/config.go
@@ -2,7 +2,6 @@ package runner
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -209,7 +208,7 @@ func defaultConfig() config {
 }
 
 func readConfig(path string) (*config, error) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/runner/util.go
+++ b/runner/util.go
@@ -4,7 +4,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -233,7 +232,7 @@ func adaptToVariousPlatforms(c *config) {
 
 // fileChecksum returns a checksum for the given file's contents.
 func fileChecksum(filename string) (checksum string, err error) {
-	contents, err := ioutil.ReadFile(filename)
+	contents, err := os.ReadFile(filename)
 	if err != nil {
 		return "", err
 	}

--- a/runner/util_test.go
+++ b/runner/util_test.go
@@ -1,7 +1,6 @@
 package runner
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 )
@@ -74,7 +73,7 @@ func TestFileChecksum(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			f, err := ioutil.TempFile("", "")
+			f, err := os.CreateTemp("", "")
 			if err != nil {
 				t.Fatalf("couldn't create temp file for test: %v", err)
 			}


### PR DESCRIPTION
From Go 1.16, `io/ioutil` package has been deprecated. I changed to moved/renamed functions.
https://go.dev/doc/go1.16#ioutil