### PR TITLE
Update go 1.17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,11 +12,11 @@ jobs:
     steps:
       - name: check out code
         uses: actions/checkout@v2
-      - name: setup Go 1.16
+      - name: setup Go 1.17
         id: go
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.16
+          go-version: ^1.17
       - name: build
         run: make build
       - name: run Unit tests.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.16
+          go-version: ^1.17
       - name: set GOVERSION
         run: echo "GOVERSION=$(go version | sed -r 's/go version go(.*)\ .*/\1/')" >> $GITHUB_ENV
       - name: set AirVersion

--- a/.github/workflows/smoke_test_reuse_job.yml
+++ b/.github/workflows/smoke_test_reuse_job.yml
@@ -14,11 +14,11 @@ jobs:
     steps:
       - name: check out code
         uses: actions/checkout@v2
-      - name: setup Go 1.16
+      - name: setup Go 1.17
         id: go
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.16
+          go-version: ^1.17
       - name: install
         run: make install
       - name: check rebuild

--- a/.github/workflows/smoke_test_window_reust_job.yml
+++ b/.github/workflows/smoke_test_window_reust_job.yml
@@ -14,11 +14,11 @@ jobs:
     steps:
       - name: check out code
         uses: actions/checkout@v2
-      - name: setup Go 1.16
+      - name: setup Go 1.17
         id: go
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.16
+          go-version: ^1.17
       - name: Setup Python
         uses: actions/setup-python@v2
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16
+FROM golang:1.17
 
 MAINTAINER Rick Yu <cosmtrek@gmail.com>
 

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ GO := GO111MODULE=on go
 
 .PHONY: init
 init:
-	go get -u golang.org/x/lint/golint
-	go get -u golang.org/x/tools/cmd/goimports
+	go install golang.org/x/lint/golint@latest
+	go install golang.org/x/tools/cmd/goimports@latest
 	@echo "Install pre-commit hook"
 	@ln -s $(shell pwd)/hooks/pre-commit $(shell pwd)/.git/hooks/pre-commit || true
 	@chmod +x ./hack/check.sh

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,16 @@
 module github.com/cosmtrek/air
 
-go 1.16
+go 1.17
 
 require (
-	github.com/creack/pty v1.1.11
 	github.com/fatih/color v1.10.0
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/imdario/mergo v0.3.12
 	github.com/pelletier/go-toml v1.8.1
-	golang.org/x/sys v0.0.0-20210514084401-e8d321eab015 // indirect
+)
+
+require (
+	github.com/mattn/go-colorable v0.1.8 // indirect
+	github.com/mattn/go-isatty v0.0.12 // indirect
+	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/creack/pty v1.1.11 h1:07n33Z8lZxZ2qwegKbObQohDhXDQxiMMz1NOUGYlesw=
-github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.10.0 h1:s36xzo75JdqLaaWoiEHk767eHiwo0598uUxyfiPkDsg=
@@ -17,8 +15,8 @@ github.com/pelletier/go-toml v1.8.1/go.mod h1:T2/BmBdy8dvIRq1a/8aqjN41wvWlN4lrap
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210514084401-e8d321eab015 h1:hZR0X1kPW+nwyJ9xRxqZk1vx5RUObAPBdKVvXPDUH/E=
-golang.org/x/sys v0.0.0-20210514084401-e8d321eab015/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e h1:fLOSk5Q00efkSvAm+4xcoXD+RRmLmmulPn5I3Y9F2EM=
+golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/smoke_test/check_rebuild/go.mod
+++ b/smoke_test/check_rebuild/go.mod
@@ -1,5 +1,5 @@
 module air.sample.com
 
-go 1.16
+go 1.17
 
 require github.com/gin-gonic/gin v1.7.7 // indirect


### PR DESCRIPTION
- Updated go version from 1.16 to 1.17
  - includes Dockerfile, github actions and go.mod.
  - The specification of go.mod has been extended to support Module graph pruning since go1.17.
    - https://go.dev/doc/go1.17#go-command
    - https://go.dev/ref/mod#graph-pruning
- Since the `go get -u` command is deprecated in go1.16, it has been replaced by the `go install` command.
  - https://go.dev/doc/go1.16#go-command

ref: https://github.com/cosmtrek/air/issues/205