### PR TITLE
update README: requires Go version 1.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ export PATH=$PATH:$(go env GOPATH)/bin <---- Confirm this line in you profile!!!
 
 ## Development
 
-Please note that it requires Go 1.13+ since I use `go mod` to manage dependencies.
+Please note that it requires Go 1.16+ since I use `go mod` to manage dependencies.
 
 ```bash
 # 1. fork this project


### PR DESCRIPTION
I have updated the README to reflect this comment.
https://github.com/cosmtrek/air/pull/229#issuecomment-987280541

I used an older version of Go(v1.14) and got the following error.

```bash
# github.com/cosmtrek/air/runner
/go/src/github.com/cosmtrek/air/runner/config.go:211:15: undefined: os.ReadFile
/go/src/github.com/cosmtrek/air/runner/util.go:231:19: undefined: os.ReadFile
```