### PR TITLE
ensure multiple processes stop to avoid address already in use errors

### DIFF
--- a/runner/engine.go
+++ b/runner/engine.go
@@ -24,11 +24,10 @@ type Engine struct {
 	buildRunCh     chan bool
 	buildRunStopCh chan bool
 	canExit        chan bool
-	binStopCh      chan bool
+	binStopChMap   map[int]chan bool
 	exitCh         chan bool
 
 	mu            sync.RWMutex
-	binRunning    bool
 	watchers      uint
 	fileChecksums *checksumMap
 
@@ -58,9 +57,8 @@ func NewEngine(cfgPath string, debugMode bool) (*Engine, error) {
 		buildRunCh:     make(chan bool, 1),
 		buildRunStopCh: make(chan bool, 1),
 		canExit:        make(chan bool, 1),
-		binStopCh:      make(chan bool),
+		binStopChMap:   make(map[int]chan bool),
 		exitCh:         make(chan bool),
-		binRunning:     false,
 		watchers:       0,
 	}
 
@@ -342,9 +340,10 @@ func (e *Engine) start() {
 
 		// if current app is running, stop it
 		e.withLock(func() {
-			if e.binRunning {
-				e.binStopCh <- true
+			for _, v := range e.binStopChMap {
+				v <- true
 			}
+			e.binStopChMap = make(map[int]chan bool)
 		})
 		go e.buildRun()
 	}
@@ -425,7 +424,11 @@ func (e *Engine) runBin() error {
 		return err
 	}
 	e.withLock(func() {
-		e.binRunning = true
+		for _, v := range e.binStopChMap {
+			v <- true
+		}
+		e.binStopChMap = make(map[int]chan bool)
+		e.binStopChMap[cmd.Process.Pid] = make(chan bool)
 	})
 	e.mainDebug("running process pid %v", cmd.Process.Pid)
 
@@ -437,7 +440,7 @@ func (e *Engine) runBin() error {
 			default:
 			}
 		}()
-		<-e.binStopCh
+		<-e.binStopChMap[cmd.Process.Pid]
 		e.mainDebug("trying to kill pid %d, cmd %+v", cmd.Process.Pid, cmd.Args)
 		defer func() {
 			stdout.Close()
@@ -453,9 +456,6 @@ func (e *Engine) runBin() error {
 		} else {
 			e.mainDebug("cmd killed, pid: %d", pid)
 		}
-		e.withLock(func() {
-			e.binRunning = false
-		})
 		cmdBinPath := cmdPath(e.config.rel(e.config.binPath()))
 		if _, err = os.Stat(cmdBinPath); os.IsNotExist(err) {
 			return
@@ -472,9 +472,10 @@ func (e *Engine) cleanup() {
 	defer e.mainLog("see you again~")
 
 	e.withLock(func() {
-		if e.binRunning {
-			e.binStopCh <- true
+		for _, v := range e.binStopChMap {
+			v <- true
 		}
+		e.binStopChMap = make(map[int]chan bool)
 	})
 	e.mainDebug("wating for	close watchers..")
 


### PR DESCRIPTION
When multiple builds are started in parallel we can end up in situations where more than one process is running at once. In a web server this leads to `2022/02/21 21:23:24 listen tcp :1234: bind: address already in use` and the appearance that code is not being updated and requires stopping/restarting air and potentially tracking down and killing orphaned processes in order to recover to a good state. 

This PR keeps track of each process started in a map based on PID and maintains a per process channel in order to be able to stop all previous processes when running a build, as well as when running `runBin`. By doing this we avoid the impacts of concurrent builds and prevent orphaned processes. This PR fixes https://github.com/cosmtrek/air/issues/216