### PR TITLE
Update example air file to document args_bin property

### DIFF
--- a/air_example.toml
+++ b/air_example.toml
@@ -36,6 +36,8 @@ stop_on_error = true
 send_interrupt = false
 # Delay after sending Interrupt signal
 kill_delay = 500 # ms
+# Add additional arguments when running binary (bin/full_bin). Will run './tmp/main hello world'.
+args_bin = ["hello", "world"]
 
 [log]
 # Show log time


### PR DESCRIPTION
This PR adds an undocumented property to `air_example.toml`

There is an undocumented property inside the codebase for specifying runtime args when executing the binary, it is called `args_bin`.

https://github.com/cosmtrek/air/blob/705822078ed1a98bf367ec28eafb3cae46a9c001/runner/config.go#L38

@xiantang Would appreciate if you can take a look 😄 