### PR TITLE
Fix run process become a zombie.

### DIFF
--- a/runner/engine.go
+++ b/runner/engine.go
@@ -434,6 +434,7 @@ func (e *Engine) runBin() error {
 	go func() {
 		_, _ = io.Copy(os.Stdout, stdout)
 		_, _ = io.Copy(os.Stderr, stderr)
+		_, _ = cmd.Process.Wait()
 	}()
 
 	killFunc := func(cmd *exec.Cmd, stdout io.ReadCloser, stderr io.ReadCloser) {


### PR DESCRIPTION
Fixes an issue where the process becomes a zombie because `runBin()` is not calling `wait()`.

see: https://man7.org/linux/man-pages/man2/wait.2.html

Environment
```
$ cat /etc/lsb-release 
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=20.04
DISTRIB_CODENAME=focal
DISTRIB_DESCRIPTION="Ubuntu 20.04.4 LTS"
```

Steps to reproduce.
```
$ echo '[build]
  bin = "app"
  cmd = "go build -o app ."
' > .air.toml

$ echo 'package main

import "fmt"

func main() {
  fmt.Println("Hello World!")
}
' > main.go

$ go mod init example.com/m

$ air
```

Before
```
$ sed -i -e 's/!/!!/g' main.go # Replace a code.
$ sleep 1 # Wait build.
$ ps f --ppid $(pidof air)
    PID TTY      STAT   TIME COMMAND
 954786 pts/7    Z      0:00 [sh] <defunct>
 954523 pts/7    Z      0:00 [sh] <defunct>
```

After
```
$ sed -i -e 's/!/!!/g' main.go # Replace a code
$ sleep 1 # Wait build.
$ ps f --ppid $(pidof air)
    PID TTY      STAT   TIME COMMAND
```