### PR TITLE
Fix command line argument handling for slice configuration parameters

### DIFF
--- a/README-zh_cn.md
+++ b/README-zh_cn.md
@@ -30,6 +30,10 @@ Air 是为 Go 应用开发设计的另外一个热重载的命令行工具。只
 
 `air --build.cmd "go build -o bin/api cmd/run.go" --build.bin "./bin/api"`
 
+对于以列表形式输入的参数，使用逗号来分隔项目:
+
+`air --build.cmd "go build -o bin/api cmd/run.go" --build.bin "./bin/api" --build.exclude_dir "templates,build"`
+
 ## 安装
 
 ### 推荐使用 install.sh

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ if you just want to config build command and run command, you can use like follo
 
 `air --build.cmd "go build -o bin/api cmd/run.go" --build.bin "./bin/api"`
 
+use a comma to separate items for arguments that take a list as input:
+
+`air --build.cmd "go build -o bin/api cmd/run.go" --build.bin "./bin/api" --build.exclude_dir "templates,build"`
+
 ## Installation
 
 ### Prefer install.sh

--- a/runner/config.go
+++ b/runner/config.go
@@ -321,7 +321,7 @@ func (c *Config) rel(path string) string {
 // WithArgs returns a new config with the given arguments added to the configuration.
 func (c *Config) WithArgs(args map[string]TomlInfo) {
 	for _, value := range args {
-		if value.Value != nil && *value.Value != "" {
+		if value.Value != nil && *value.Value != UnsetDefault {
 			v := reflect.ValueOf(c)
 			setValue2Struct(v, value.fieldPath, *value.Value)
 		}

--- a/runner/config.go
+++ b/runner/config.go
@@ -321,7 +321,7 @@ func (c *Config) rel(path string) string {
 // WithArgs returns a new config with the given arguments added to the configuration.
 func (c *Config) WithArgs(args map[string]TomlInfo) {
 	for _, value := range args {
-		if value.Value != nil && *value.Value != UnsetDefault {
+		if value.Value != nil && *value.Value != unsetDefault {
 			v := reflect.ValueOf(c)
 			setValue2Struct(v, value.fieldPath, *value.Value)
 		}

--- a/runner/engine_test.go
+++ b/runner/engine_test.go
@@ -563,7 +563,7 @@ func TestRebuildWhenRunCmdUsingDLV(t *testing.T) {
 	go func() {
 		engine.Run()
 	}()
-	if err := waitingPortReady(t, port, time.Second*20); err != nil {
+	if err := waitingPortReady(t, port, time.Second*40); err != nil {
 		t.Fatalf("Should not be fail: %s.", err)
 	}
 
@@ -588,7 +588,7 @@ func TestRebuildWhenRunCmdUsingDLV(t *testing.T) {
 	}
 	t.Logf("connection refused")
 	time.Sleep(time.Second * 2)
-	err = waitingPortReady(t, port, time.Second*20)
+	err = waitingPortReady(t, port, time.Second*40)
 	if err != nil {
 		t.Fatalf("Should not be fail: %s.", err)
 	}

--- a/runner/flag.go
+++ b/runner/flag.go
@@ -4,12 +4,14 @@ import (
 	"flag"
 )
 
+const UnsetDefault = "DEFAULT"
+
 // ParseConfigFlag parse toml information for flag
 func ParseConfigFlag(f *flag.FlagSet) map[string]TomlInfo {
 	c := Config{}
 	m := flatConfig(c)
 	for k, v := range m {
-		f.StringVar(v.Value, k, "", "")
+		f.StringVar(v.Value, k, UnsetDefault, "")
 	}
 	return m
 }

--- a/runner/flag.go
+++ b/runner/flag.go
@@ -4,14 +4,14 @@ import (
 	"flag"
 )
 
-const UnsetDefault = "DEFAULT"
+const unsetDefault = "DEFAULT"
 
 // ParseConfigFlag parse toml information for flag
 func ParseConfigFlag(f *flag.FlagSet) map[string]TomlInfo {
 	c := Config{}
 	m := flatConfig(c)
 	for k, v := range m {
-		f.StringVar(v.Value, k, UnsetDefault, "")
+		f.StringVar(v.Value, k, unsetDefault, "")
 	}
 	return m
 }

--- a/runner/flag_test.go
+++ b/runner/flag_test.go
@@ -103,9 +103,9 @@ func TestConfigRuntimeArgs(t *testing.T) {
 		},
 		{
 			name: "check exclude_regex",
-			args: []string{"--build.exclude_regex", `["_test.go"]`},
+			args: []string{"--build.exclude_regex", "_test.go,.html"},
 			check: func(t *testing.T, conf *Config) {
-				assert.Equal(t, []string{"_test.go"}, conf.Build.ExcludeRegex)
+				assert.Equal(t, []string{"_test.go", ".html"}, conf.Build.ExcludeRegex)
 			},
 		},
 	}

--- a/runner/flag_test.go
+++ b/runner/flag_test.go
@@ -108,6 +108,15 @@ func TestConfigRuntimeArgs(t *testing.T) {
 				assert.Equal(t, []string{"_test.go", ".html"}, conf.Build.ExcludeRegex)
 			},
 		},
+		{
+			name: "check exclude_regex with empty string",
+			args: []string{"--build.exclude_regex", ""},
+			check: func(t *testing.T, conf *Config) {
+				assert.Equal(t, []string{}, conf.Build.ExcludeRegex)
+				t.Logf("%+v", conf.Build.ExcludeDir)
+				assert.NotEqual(t, []string{}, conf.Build.ExcludeDir)
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/runner/util.go
+++ b/runner/util.go
@@ -300,7 +300,11 @@ func setValue2Struct(v reflect.Value, fieldName string, value string) {
 		case reflect.String:
 			field.SetString(value)
 		case reflect.Slice:
-			field.Set(reflect.ValueOf(strings.Split(value, sliceCmdArgSeparator)))
+			if len(value) == 0 {
+				field.Set(reflect.ValueOf([]string{}))
+			} else {
+				field.Set(reflect.ValueOf(strings.Split(value, sliceCmdArgSeparator)))
+			}
 		case reflect.Int64:
 			i, _ := strconv.ParseInt(value, 10, 64)
 			field.SetInt(i)

--- a/runner/util.go
+++ b/runner/util.go
@@ -16,6 +16,10 @@ import (
 	"github.com/fsnotify/fsnotify"
 )
 
+const (
+	sliceCmdArgSeparator = ","
+)
+
 func (e *Engine) mainLog(format string, v ...interface{}) {
 	e.logWithLock(func() {
 		e.logger.main()(format, v...)
@@ -296,9 +300,7 @@ func setValue2Struct(v reflect.Value, fieldName string, value string) {
 		case reflect.String:
 			field.SetString(value)
 		case reflect.Slice:
-			if field.Len() == 0 {
-				field.Set(reflect.Append(field, reflect.ValueOf(value)))
-			}
+			field.Set(reflect.ValueOf(strings.Split(value, sliceCmdArgSeparator)))
 		case reflect.Int64:
 			i, _ := strconv.ParseInt(value, 10, 64)
 			field.SetInt(i)

--- a/runner/util_test.go
+++ b/runner/util_test.go
@@ -256,3 +256,21 @@ func TestNestStructValue(t *testing.T) {
 	setValue2Struct(v, "Build.Cmd", "asdasd")
 	assert.Equal(t, "asdasd", c.Build.Cmd)
 }
+
+func TestNestStructArrayValue(t *testing.T) {
+	c := Config{}
+	v := reflect.ValueOf(&c)
+	setValue2Struct(v, "Build.ExcludeDir", "dir1,dir2")
+	assert.Equal(t, []string{"dir1", "dir2"}, c.Build.ExcludeDir)
+}
+
+func TestNestStructArrayValueOverride(t *testing.T) {
+	c := Config{
+		Build: cfgBuild{
+			ExcludeDir: []string{"default1", "default2"},
+		},
+	}
+	v := reflect.ValueOf(&c)
+	setValue2Struct(v, "Build.ExcludeDir", "dir1,dir2")
+	assert.Equal(t, []string{"dir1", "dir2"}, c.Build.ExcludeDir)
+}


### PR DESCRIPTION
It seems slice configuration parameters such as `ExcludeDir` cannot be set correctly with command line arguments (nor override default config). The test for `--build.exclude_regex` only passes because the test value corresponds with the default value (set in `defaultConfig`), it's not actually set by the parameter in the test.

I propose to treat the command line arguments for such config parameters as comma separated strings. Setting a value would work as e.g. `--build.exclude_dir "templates,build"`.