### PR TITLE
fixes air_example.toml regex expression

### DIFF
--- a/air_example.toml
+++ b/air_example.toml
@@ -21,7 +21,7 @@ include_dir = []
 # Exclude files.
 exclude_file = []
 # Exclude specific regular expressions.
-exclude_regex = ["_test.go"]
+exclude_regex = ["_test\\.go"]
 # Exclude unchanged files.
 exclude_unchanged = true
 # Follow symlink for directories

--- a/runner/engine_test.go
+++ b/runner/engine_test.go
@@ -65,7 +65,7 @@ func TestRegexes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Should not be fail: %s.", err)
 	}
-	engine.config.Build.ExcludeRegex = []string{"foo.html$", "bar"}
+	engine.config.Build.ExcludeRegex = []string{"foo\\.html$", "bar", "_test\\.go"}
 
 	result, err := engine.isExcludeRegex("./test/foo.html")
 	if err != nil {
@@ -89,6 +89,21 @@ func TestRegexes(t *testing.T) {
 	}
 	if result {
 		t.Errorf("expected '%t' but got '%t'", false, result)
+	}
+
+	result, err = engine.isExcludeRegex("./myPackage/goFile_testxgo")
+	if err != nil {
+		t.Fatalf("Should not be fail: %s.", err)
+	}
+	if result {
+		t.Errorf("expected '%t' but got '%t'", false, result)
+	}
+	result, err = engine.isExcludeRegex("./myPackage/goFile_test.go")
+	if err != nil {
+		t.Fatalf("Should not be fail: %s.", err)
+	}
+	if result != true {
+		t.Errorf("expected '%t' but got '%t'", true, result)
 	}
 }
 


### PR DESCRIPTION
I think this regex expression should be "_test\\.go". The '.' character matches any character in regex.