### PR TITLE
Allow output logging from fmt or log packages when executable is running.

### DIFF
--- a/runner/engine.go
+++ b/runner/engine.go
@@ -433,6 +433,9 @@ func (e *Engine) runBin() error {
 	}
 	go io.Copy(os.Stdout, stdout)
 	go io.Copy(os.Stderr, stderr)
+	go func() {
+		_, _ = cmd.Process.Wait()
+	}()
 
 	killFunc := func(cmd *exec.Cmd, stdout io.ReadCloser, stderr io.ReadCloser) {
 		defer func() {

--- a/runner/engine.go
+++ b/runner/engine.go
@@ -431,11 +431,8 @@ func (e *Engine) runBin() error {
 	if err != nil {
 		return err
 	}
-	go func() {
-		_, _ = io.Copy(os.Stdout, stdout)
-		_, _ = io.Copy(os.Stderr, stderr)
-		_, _ = cmd.Process.Wait()
-	}()
+	go io.Copy(os.Stdout, stdout)
+	go io.Copy(os.Stderr, stderr)
 
 	killFunc := func(cmd *exec.Cmd, stdout io.ReadCloser, stderr io.ReadCloser) {
 		defer func() {


### PR DESCRIPTION
As noted in issue #50, output logging only shows up when `air` is closed.  This is a bit annoying since you have to close `air` (and most likely restart it) to see any log messages.  This change fixes the output to occur while `air` is running and thus mirrors the functionality in  `fresh`.  I am unsure of any unintended side-effects of this change, but I have not noticed any thus far.

It looks like this bug/unintended functionality/whatever-you-want-to-call-it is caused by the wrapping of the `io.Copy()` calls for stdout and stderr into one goroutine and using with the `cmd.Process.Wait()` call.  The `Wait()` call hangs/blocks endlessly until the binary (i.e. `air`) is closed/stopped thus not allowing the copying of the stdout or stderr to the terminal you ran `air` in.  However, just removing the `Wait()` call did not allow logging to work; the `Copy()` calls had to be split into separate goroutines as well.  Thus, at the end of the day, the code to fix this is simply a copying of the code from `fresh`.

References:
 - `fresh` lines https://github.com/gravityblast/fresh/blob/master/runner/runner.go#L28-L29.
 - `air` lines https://github.com/cosmtrek/air/blob/6f18a44eb4aa1eac4956755d7efc3605fc42f2ac/runner/engine.go#L434-L437