### PR TITLE
Make root config support path like "..", "../..", etc

### DIFF
--- a/runner/util.go
+++ b/runner/util.go
@@ -65,7 +65,7 @@ func (e *Engine) isTestDataDir(path string) bool {
 }
 
 func isHiddenDirectory(path string) bool {
-	return len(path) > 1 && strings.HasPrefix(filepath.Base(path), ".")
+	return len(path) > 1 && strings.HasPrefix(filepath.Base(path), ".") && filepath.Base(path) != ".."
 }
 
 func cleanPath(path string) string {


### PR DESCRIPTION
For example, my project tree look like this:
```
Myproject/
┣ example/
┃ ┣ .air.toml
┃ ┣ go.mod
┃ ┣ go.sum
┃ ┗ main.go
┣ module/
┃ ┣ go.mod
┃ ┗ module.go
┣ .gitignore
┗ go.work
```
I want to run `air` in `example` folder but watch `Myproject` folder. In `.air.toml`, if I set root to `..`, it does not work, I have to set it to `../../Myproject`.

This PR makes support for `..` for root setting.