### PR TITLE
Preserve runtime arguments when using `full_bin`

### DIFF
--- a/runner/config.go
+++ b/runner/config.go
@@ -290,6 +290,10 @@ func (c *Config) preprocess() error {
 
 	adaptToVariousPlatforms(c)
 
+	// Join runtime arguments with the configuration arguments
+	runtimeArgs := flag.Args()
+	c.Build.ArgsBin = append(c.Build.ArgsBin, runtimeArgs...)
+
 	c.Build.ExcludeDir = ed
 	if len(c.Build.FullBin) > 0 {
 		c.Build.Bin = c.Build.FullBin
@@ -298,10 +302,6 @@ func (c *Config) preprocess() error {
 	// Fix windows CMD processor
 	// CMD will not recognize relative path like ./tmp/server
 	c.Build.Bin, err = filepath.Abs(c.Build.Bin)
-
-	// Join runtime arguments with the configuration arguments
-	runtimeArgs := flag.Args()
-	c.Build.ArgsBin = append(c.Build.ArgsBin, runtimeArgs...)
 
 	return err
 }


### PR DESCRIPTION
Fixes https://github.com/cosmtrek/air/issues/320.

This PR fixes an issue where runtime args were being ignored when specifying `full_bin` as opposed to `bin` properties in the config.