### PR TITLE
Proposed change to fix stop_on_error=false not working in .air.toml

### DIFF
--- a/runner/config.go
+++ b/runner/config.go
@@ -211,7 +211,6 @@ func defaultConfig() Config {
 		ArgsBin:      []string{},
 		ExcludeRegex: []string{"_test.go"},
 		Delay:        1000,
-		StopOnError:  true,
 	}
 	if runtime.GOOS == PlatformWindows {
 		build.Bin = `tmp\main.exe`


### PR DESCRIPTION
Hello guys,

I found a funny bug: I tried to set `stop_on_error = false` in `.air.toml`, but it had no effect. After some debugging, it turns out that the reason is this `mergo` issue: https://github.com/imdario/mergo/issues/129

The problem is that `stop_on_error` is defined as `true` in the `defaultConfig()` function, but `mergo` won't overwrite `true` with `false` from the `defaultPathConfig()` function.

Other solutions are possible, but this looks the simplest without truly introducing `true`/`false`/`undefined` in the concept of air's config for the sake of this one value. Since the `stop_on_error = true` snippet is in the example config file since 2020, and actually before that the default was the current `false` (because the feature was non-existent), I think it would cause a problem for very few people, and make the feature switch-off-able again.

Thanks for the great tool, and keep up the good work!

Kristof