### PR TITLE
Add `include_file` option

### DIFF
--- a/air_example.toml
+++ b/air_example.toml
@@ -18,6 +18,8 @@ include_ext = ["go", "tpl", "tmpl", "html"]
 exclude_dir = ["assets", "tmp", "vendor", "frontend/node_modules"]
 # Watch these directories if you specified.
 include_dir = []
+# Watch these files.
+include_file = []
 # Exclude files.
 exclude_file = []
 # Exclude specific regular expressions.

--- a/runner/config.go
+++ b/runner/config.go
@@ -208,6 +208,7 @@ func defaultConfig() Config {
 		IncludeExt:   []string{"go", "tpl", "tmpl", "html"},
 		IncludeDir:   []string{},
 		ExcludeFile:  []string{},
+		IncludeFile:  []string{},
 		ExcludeDir:   []string{"assets", "tmp", "vendor", "testdata"},
 		ArgsBin:      []string{},
 		ExcludeRegex: []string{"_test.go"},

--- a/runner/config.go
+++ b/runner/config.go
@@ -43,6 +43,7 @@ type cfgBuild struct {
 	ExcludeDir       []string      `toml:"exclude_dir"`
 	IncludeDir       []string      `toml:"include_dir"`
 	ExcludeFile      []string      `toml:"exclude_file"`
+	IncludeFile      []string      `toml:"include_file"`
 	ExcludeRegex     []string      `toml:"exclude_regex"`
 	ExcludeUnchanged bool          `toml:"exclude_unchanged"`
 	FollowSymlink    bool          `toml:"follow_symlink"`

--- a/runner/engine.go
+++ b/runner/engine.go
@@ -111,6 +111,9 @@ func (e *Engine) watching(root string) error {
 	return filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
 		// NOTE: path is absolute
 		if info != nil && !info.IsDir() {
+			if e.checkIncludeFile(path) {
+				return e.watchPath(path)
+			}
 			return nil
 		}
 		// exclude tmp dir
@@ -138,7 +141,7 @@ func (e *Engine) watching(root string) error {
 			return filepath.SkipDir
 		}
 		if isIn {
-			return e.watchDir(path)
+			return e.watchPath(path)
 		}
 		return nil
 	})
@@ -174,7 +177,7 @@ func (e *Engine) cacheFileChecksums(root string) error {
 					return err
 				}
 				if linkInfo.IsDir() {
-					err = e.watchDir(link)
+					err = e.watchPath(link)
 					if err != nil {
 						return err
 					}
@@ -204,7 +207,7 @@ func (e *Engine) cacheFileChecksums(root string) error {
 	})
 }
 
-func (e *Engine) watchDir(path string) error {
+func (e *Engine) watchPath(path string) error {
 	if err := e.watcher.Add(path); err != nil {
 		e.watcherLog("failed to watch %s, error: %s", path, err.Error())
 		return err

--- a/runner/engine_test.go
+++ b/runner/engine_test.go
@@ -811,7 +811,7 @@ func TestShouldIncludeIncludedFile(t *testing.T) {
 	config := `
 [build]
 cmd = "cp main.sh build.sh"
-bin = "sh build.sh"
+full_bin = "sh build.sh"
 include_file = ["main.sh"]
 `
 	if err := ioutil.WriteFile(dftTOML, []byte(config), 0644); err != nil {

--- a/runner/engine_test.go
+++ b/runner/engine_test.go
@@ -665,6 +665,7 @@ bin = "tmp/main"
 exclude_regex = []
 exclude_dir = ["test"]
 exclude_file = ["main.go"]
+include_file = ["test/not_a_test.go"]
 
 `
 	if err := ioutil.WriteFile(dftTOML, []byte(config), 0644); err != nil {
@@ -679,6 +680,7 @@ exclude_file = ["main.go"]
 	assert.Equal(t, []string{"test"}, engine.config.Build.ExcludeDir)
 	// add new config
 	assert.Equal(t, []string{"main.go"}, engine.config.Build.ExcludeFile)
+	assert.Equal(t, []string{"test/not_a_test.go"}, engine.config.Build.IncludeFile)
 	assert.Equal(t, "go build .", engine.config.Build.Cmd)
 
 }

--- a/runner/util.go
+++ b/runner/util.go
@@ -107,6 +107,23 @@ func (e *Engine) checkIncludeDir(path string) (bool, bool) {
 	return false, walkDir
 }
 
+func (e *Engine) checkIncludeFile(path string) bool {
+	cleanName := cleanPath(e.config.rel(path))
+	iFile := e.config.Build.IncludeFile
+	if len(iFile) == 0 { // ignore empty
+		return false
+	}
+	if cleanName == "." {
+		return false
+	}
+	for _, d := range iFile {
+		if d == cleanName {
+			return true
+		}
+	}
+	return false
+}
+
 func (e *Engine) isIncludeExt(path string) bool {
 	ext := filepath.Ext(path)
 	for _, v := range e.config.Build.IncludeExt {

--- a/runner/util_test.go
+++ b/runner/util_test.go
@@ -274,3 +274,16 @@ func TestNestStructArrayValueOverride(t *testing.T) {
 	setValue2Struct(v, "Build.ExcludeDir", "dir1,dir2")
 	assert.Equal(t, []string{"dir1", "dir2"}, c.Build.ExcludeDir)
 }
+
+func TestCheckIncludeFile(t *testing.T) {
+	e := Engine{
+		config: &Config{
+			Build: cfgBuild{
+				IncludeFile: []string{"main.go"},
+				SendInterrupt: false,
+			},
+		},
+	}
+	assert.Equal(t, e.checkIncludeFile("main.go"), true)
+	assert.Equal(t, e.checkIncludeFile("no.go"), false)
+}

--- a/runner/util_test.go
+++ b/runner/util_test.go
@@ -279,7 +279,7 @@ func TestCheckIncludeFile(t *testing.T) {
 	e := Engine{
 		config: &Config{
 			Build: cfgBuild{
-				IncludeFile: []string{"main.go"},
+				IncludeFile:   []string{"main.go"},
 				SendInterrupt: false,
 			},
 		},

--- a/runner/util_test.go
+++ b/runner/util_test.go
@@ -286,4 +286,5 @@ func TestCheckIncludeFile(t *testing.T) {
 	}
 	assert.Equal(t, e.checkIncludeFile("main.go"), true)
 	assert.Equal(t, e.checkIncludeFile("no.go"), false)
+	assert.Equal(t, e.checkIncludeFile("."), false)
 }

--- a/runner/util_test.go
+++ b/runner/util_test.go
@@ -280,7 +280,6 @@ func TestCheckIncludeFile(t *testing.T) {
 		config: &Config{
 			Build: cfgBuild{
 				IncludeFile:   []string{"main.go"},
-				SendInterrupt: false,
 			},
 		},
 	}


### PR DESCRIPTION
Useful option to specify individual files to watch. I renamed the `watchDir` function to `watchPath` because it can also handle single files fine (`filepath.Walk` emits a single file if passed a file path).

Fixes: https://github.com/cosmtrek/air/issues/307

Example of it working with a pure `include_dir` and `include_file` config:

<img width="251" alt="image" src="https://user-images.githubusercontent.com/115237/196235866-2b8f4f72-e812-4b5d-b3fb-ecc22ba55767.png">
