### PR TITLE
Add the tutorial for docker users

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ services:
 ## Installation and Usage for Docker users who don't want to use air image
 
 `Dockerfile`
-```
+```Dockerfile
 # Choose whatever you want, version >= 1.16
 FROM golang:1.19-alpine
 
@@ -179,7 +179,7 @@ CMD ["air", "-c", ".air.toml"]
 ```
 
 `docker-compose.yaml`
-```
+```yaml
 version: "3.8"
 services:
   web:

--- a/README.md
+++ b/README.md
@@ -161,6 +161,39 @@ services:
 
 `air -d` prints all logs.
 
+## Installation and Usage for Docker users who don't want to use air image
+
+`Dockerfile`
+```
+# Choose whatever you want, version >= 1.16
+FROM golang:1.19-alpine
+
+WORKDIR /app
+
+RUN go install github.com/cosmtrek/air@latest
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+CMD ["air", "-c", ".air.toml"]
+```
+
+`docker-compose.yaml`
+```
+version: "3.8"
+services:
+  web:
+    build:
+      context: .
+      # Correct the path to your Dockerfile
+      dockerfile: Dockerfile
+    ports:
+      - 8080:3000
+    # Important to bind/mount your codebase dir to /app dir for live reload
+    volumes:
+      - ./:/app
+```
+
 ## Q&A
 
 ### "command not found: air" or "No such file or directory"


### PR DESCRIPTION
I really love Air features. However, when I started dockerize my Golang app, Air did not work. I started some search and found some alternative libs, but I still love Air. So I found a way to make air work with docker-compose (not work by only `docker run` command with `volume` flag for some reason)

For this PR I just add Dockerfile and docker-compose.yaml examples for Docker users who don't want to use air images with fixed Golang version and Linux distro. I think it will help someone who beginner to Air and Docker.