### PR TITLE
Feat clear on rebuild

### DIFF
--- a/runner/config.go
+++ b/runner/config.go
@@ -240,7 +240,7 @@ func defaultConfig() Config {
 		Misc:        misc,
 		Screen: cfgScreen{
 			ClearOnRebuild: false,
-			KeepScroll:     false,
+			KeepScroll:     true,
 		},
 	}
 }

--- a/runner/config.go
+++ b/runner/config.go
@@ -86,6 +86,7 @@ type cfgMisc struct {
 
 type cfgScreen struct {
 	ClearOnRebuild bool `toml:"clear_on_rebuild"`
+	KeepScroll     bool `toml:"keep_scroll"`
 }
 
 type sliceTransformer struct{}
@@ -237,6 +238,10 @@ func defaultConfig() Config {
 		Color:       color,
 		Log:         log,
 		Misc:        misc,
+		Screen: cfgScreen{
+			ClearOnRebuild: false,
+			KeepScroll:     false,
+		},
 	}
 }
 

--- a/runner/engine.go
+++ b/runner/engine.go
@@ -330,9 +330,14 @@ func (e *Engine) start() {
 			time.Sleep(e.config.buildDelay())
 			e.flushEvents()
 
-			// clean on rebuild https://stackoverflow.com/questions/22891644/how-can-i-clear-the-terminal-screen-in-go
 			if e.config.Screen.ClearOnRebuild {
-				fmt.Println("\033[2J")
+				if e.config.Screen.KeepScroll {
+					// https://stackoverflow.com/questions/22891644/how-can-i-clear-the-terminal-screen-in-go
+					fmt.Print("\033[2J")
+				} else {
+					// https://stackoverflow.com/questions/5367068/clear-a-terminal-screen-for-real/5367075#5367075
+					fmt.Println("\033c")
+				}
 			}
 
 			e.mainLog("%s has changed", e.config.rel(filename))

--- a/runner/engine.go
+++ b/runner/engine.go
@@ -336,7 +336,7 @@ func (e *Engine) start() {
 					fmt.Print("\033[2J")
 				} else {
 					// https://stackoverflow.com/questions/5367068/clear-a-terminal-screen-for-real/5367075#5367075
-					fmt.Println("\033c")
+					fmt.Print("\033c")
 				}
 			}
 


### PR DESCRIPTION
The current clear command fmt.Print("\033[2J") is not completely clear terminal as we can back to it with scroll.
I understand that some people may like to keep the logs and come back with a scroll.
So I added a new param as keep_scroll too.
Also added:
```
Screen: cfgScreen{
	ClearOnRebuild: false,
	KeepScroll:     false,
},
``` 
So people can see the options