### PR TITLE
Make `include_file` overrule `include_ext`

### DIFF
--- a/runner/engine.go
+++ b/runner/engine.go
@@ -186,7 +186,7 @@ func (e *Engine) cacheFileChecksums(root string) error {
 			}
 		}
 
-		if e.isExcludeFile(path) || !e.isIncludeExt(path) {
+		if e.isExcludeFile(path) || !e.isIncludeExt(ev.Name) && !e.checkIncludeFile(path) {
 			e.watcherDebug("!exclude checksum %s", e.config.rel(path))
 			return nil
 		}
@@ -251,7 +251,7 @@ func (e *Engine) watchPath(path string) error {
 				if excludeRegex {
 					break
 				}
-				if !e.isIncludeExt(ev.Name) {
+				if !e.isIncludeExt(ev.Name) && !e.checkIncludeFile(path) {
 					break
 				}
 				e.watcherDebug("%s has changed", e.config.rel(ev.Name))
@@ -317,7 +317,7 @@ func (e *Engine) start() {
 			e.mainDebug("exit in start")
 			return
 		case filename = <-e.eventCh:
-			if !e.isIncludeExt(filename) {
+			if !e.isIncludeExt(filename) && !e.checkIncludeFile(filename) {
 				continue
 			}
 			if e.config.Build.ExcludeUnchanged {

--- a/runner/engine.go
+++ b/runner/engine.go
@@ -186,7 +186,7 @@ func (e *Engine) cacheFileChecksums(root string) error {
 			}
 		}
 
-		if e.isExcludeFile(path) || !e.isIncludeExt(ev.Name) && !e.checkIncludeFile(path) {
+		if e.isExcludeFile(path) || !e.isIncludeExt(path) && !e.checkIncludeFile(path) {
 			e.watcherDebug("!exclude checksum %s", e.config.rel(path))
 			return nil
 		}

--- a/runner/engine_test.go
+++ b/runner/engine_test.go
@@ -804,7 +804,7 @@ func TestShouldIncludeIncludedFile(t *testing.T) {
 [build]
 cmd = "true" # do nothing
 full_bin = "sh main.sh"
-include_ext = ["sh"]
+include_ext = []
 include_dir = ["nonexist"] # prevent default "." watch from taking effect
 include_file = ["main.sh"]
 `


### PR DESCRIPTION
A file can now be in `include_file` without having its extension in `include_ext`, which I generally think is the expected behaviour because explicit filenames are more specific than extensions.

Fixes: https://github.com/cosmtrek/air/issues/350