### PR TITLE
Feat: option to silence verbose air logging using `main_only` in config

### DIFF
--- a/air_example.toml
+++ b/air_example.toml
@@ -44,6 +44,7 @@ args_bin = ["hello", "world"]
 [log]
 # Show log time
 time = false
+main_only = false
 
 [color]
 # Customize each part's color. If no color found, use the raw app log.

--- a/air_example.toml
+++ b/air_example.toml
@@ -44,6 +44,7 @@ args_bin = ["hello", "world"]
 [log]
 # Show log time
 time = false
+# Only show main log (silences watcher, build, runner)
 main_only = false
 
 [color]

--- a/runner/config.go
+++ b/runner/config.go
@@ -69,7 +69,8 @@ func (c *cfgBuild) RegexCompiled() ([]*regexp.Regexp, error) {
 }
 
 type cfgLog struct {
-	AddTime bool `toml:"time"`
+	AddTime  bool `toml:"time"`
+	MainOnly bool `toml:"main_only"`
 }
 
 type cfgColor struct {
@@ -219,7 +220,8 @@ func defaultConfig() Config {
 		build.Cmd = "go build -o ./tmp/main.exe ."
 	}
 	log := cfgLog{
-		AddTime: false,
+		AddTime:  false,
+		MainOnly: false,
 	}
 	color := cfgColor{
 		Main:    "magenta",

--- a/runner/util.go
+++ b/runner/util.go
@@ -33,21 +33,27 @@ func (e *Engine) mainDebug(format string, v ...interface{}) {
 }
 
 func (e *Engine) buildLog(format string, v ...interface{}) {
-	e.logWithLock(func() {
-		e.logger.build()(format, v...)
-	})
+	if e.debugMode || !e.config.Log.MainOnly {
+		e.logWithLock(func() {
+			e.logger.build()(format, v...)
+		})
+	}
 }
 
 func (e *Engine) runnerLog(format string, v ...interface{}) {
-	e.logWithLock(func() {
-		e.logger.runner()(format, v...)
-	})
+	if e.debugMode || !e.config.Log.MainOnly {
+		e.logWithLock(func() {
+			e.logger.runner()(format, v...)
+		})
+	}
 }
 
 func (e *Engine) watcherLog(format string, v ...interface{}) {
-	e.logWithLock(func() {
-		e.logger.watcher()(format, v...)
-	})
+	if e.debugMode || !e.config.Log.MainOnly {
+		e.logWithLock(func() {
+			e.logger.watcher()(format, v...)
+		})
+	}
 }
 
 func (e *Engine) watcherDebug(format string, v ...interface{}) {


### PR DESCRIPTION
# Feat: option to silence verbose air logging using `main_only` in config

Hides verbose `air` logging - (which can get in the way of the target program logs).

Defaults to `false` - nothing should change by default, only after a user sets `main_only = true` in the config.

Debug mode overrides this option (if debug mode, show all logs).

Relates to #354 , #201 