### PR TITLE
Log output doesn't show until close #50

### DIFF
--- a/runner/engine.go
+++ b/runner/engine.go
@@ -439,8 +439,13 @@ func (e *Engine) runBin() error {
 	if err != nil {
 		return err
 	}
+
 	go func() {
 		_, _ = io.Copy(os.Stdout, stdout)
+		_, _ = cmd.Process.Wait()
+	}()
+
+	go func() {
 		_, _ = io.Copy(os.Stderr, stderr)
 		_, _ = cmd.Process.Wait()
 	}()


### PR DESCRIPTION
This seems to work on Ubuntu and Windows.