### PR TITLE
Some fixes to stop confusion of kill delay value

### DIFF
--- a/air_example.toml
+++ b/air_example.toml
@@ -37,7 +37,7 @@ stop_on_error = true
 # Send Interrupt signal before killing process (windows does not support this feature)
 send_interrupt = false
 # Delay after sending Interrupt signal
-kill_delay = 500 # ms
+kill_delay = "500ms"
 # Rerun binary or not
 rerun = false
 # Delay after each executions

--- a/runner/flag_test.go
+++ b/runner/flag_test.go
@@ -39,8 +39,14 @@ func TestFlag(t *testing.T) {
 		},
 		{
 			name:     "check int",
-			args:     []string{"--build.kill_delay", "1000"},
+			args:     []string{"--build.delay", "1000"},
 			expected: "1000",
+			key:      "build.delay",
+		},
+		{
+			name:     "check time.Duration",
+			args:     []string{"--build.kill_delay", "1s"},
+			expected: "1s",
 			key:      "build.kill_delay",
 		},
 		{
@@ -87,10 +93,18 @@ func TestConfigRuntimeArgs(t *testing.T) {
 		},
 		{
 			name: "check int64",
-			args: []string{"--build.kill_delay", "1000"},
+			args: []string{"--build.delay", "1000"},
+			key:  "build.delay",
+			check: func(t *testing.T, conf *Config) {
+				assert.Equal(t, 1000, conf.Build.Delay)
+			},
+		},
+		{
+			name: "check time.Duration",
+			args: []string{"--build.kill_delay", "500000000"},
 			key:  "build.kill_delay",
 			check: func(t *testing.T, conf *Config) {
-				assert.Equal(t, time.Duration(1000), conf.Build.KillDelay)
+				assert.Equal(t, time.Duration(500*time.Millisecond), conf.Build.KillDelay)
 			},
 		},
 		{


### PR DESCRIPTION
After reviewing several previous commits, I discovered that the method in which the kill_delay was specified led to some confusion.

In the initial implementation of kill_delay in commit #49, there was a confusing specification that indicated the value specified as an integer would be parsed as time.Duration and multiplied by time.Second. Therefore, specifying kill_delay as `kill_delay = 2` would mean waiting for `2 * 1` second, but specifying kill_delay as `kill_delay = "2s"` would mean waiting for `2000000000 * 1` second.

In the subsequent commit ff8c2ed, an explanation (# ms) was added to air_example.toml, and a fix was made to multiply by time.Millisecond. Users who refer to air_example.toml can now use this option as expected, but unfortunately, those who execute air init will see a generated config file with `kill_delay = "0s"`.

Then, commit #287 was introduced, and it seemed to aim to help users who configure their kill_delay as `"1s"`. As a result, the configurations that refer to air_example.toml no longer work as expected.

The main topic of this pull request is to clarify the specification for kill_delay to avoid confusion. This involves fixing air_example.toml and some test values with kill_delay. It is now clarified that kill_delay should be a string such as `"500ms"`.

Ideally, the WithArgs method should also be fixed to parse time.Duration, but I still believe this pull request is worthwhile!