### PR TITLE
Load environment variables from file

### DIFF
--- a/air_example.toml
+++ b/air_example.toml
@@ -44,6 +44,8 @@ rerun = false
 rerun_delay = 500
 # Add additional arguments when running binary (bin/full_bin). Will run './tmp/main hello world'.
 args_bin = ["hello", "world"]
+# Load environment variables from a file
+env_file = ".env"
 
 [log]
 # Show log time

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/joho/godotenv v1.5.1 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.17 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
 github.com/imdario/mergo v0.3.13 h1:lFzP57bqS/wsqKssCGmtLAb8A0wKjLGrve2q3PPVcBk=
 github.com/imdario/mergo v0.3.13/go.mod h1:4lJ1jqUDcsbIECGy0RUJAXNIhg+6ocWgb1ALK2O4oXg=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=

--- a/runner/config.go
+++ b/runner/config.go
@@ -53,6 +53,7 @@ type cfgBuild struct {
 	KillDelay        time.Duration `toml:"kill_delay"`
 	Rerun            bool          `toml:"rerun"`
 	RerunDelay       int           `toml:"rerun_delay"`
+	EnvFile          string        `toml:"env_file"`
 	regexCompiled    []*regexp.Regexp
 }
 

--- a/runner/util_darwin.go
+++ b/runner/util_darwin.go
@@ -25,12 +25,14 @@ func (e *Engine) killCmd(cmd *exec.Cmd) (pid int, err error) {
 	return pid, err
 }
 
-func (e *Engine) startCmd(cmd string) (*exec.Cmd, io.ReadCloser, io.ReadCloser, error) {
+func (e *Engine) startCmd(cmd string, envVariables ...string) (*exec.Cmd, io.ReadCloser, io.ReadCloser, error) {
 	c := exec.Command("/bin/sh", "-c", cmd)
 	// because using pty cannot have same pgid
 	c.SysProcAttr = &syscall.SysProcAttr{
 		Setpgid: true,
 	}
+
+	c.Env = append(c.Env, envVariables...)
 
 	stderr, err := c.StderrPipe()
 	if err != nil {

--- a/runner/util_linux.go
+++ b/runner/util_linux.go
@@ -28,8 +28,10 @@ func (e *Engine) killCmd(cmd *exec.Cmd) (pid int, err error) {
 	return
 }
 
-func (e *Engine) startCmd(cmd string) (*exec.Cmd, io.ReadCloser, io.ReadCloser, error) {
+func (e *Engine) startCmd(cmd string, envVariables ...string) (*exec.Cmd, io.ReadCloser, io.ReadCloser, error) {
 	c := exec.Command("/bin/sh", "-c", cmd)
+	c.Env = append(c.Env, envVariables...)
+
 	f, err := pty.Start(c)
 	return c, f, f, err
 }

--- a/runner/util_windows.go
+++ b/runner/util_windows.go
@@ -14,13 +14,15 @@ func (e *Engine) killCmd(cmd *exec.Cmd) (pid int, err error) {
 	return pid, kill.Run()
 }
 
-func (e *Engine) startCmd(cmd string) (*exec.Cmd, io.ReadCloser, io.ReadCloser, error) {
+func (e *Engine) startCmd(cmd string, envVariables ...string) (*exec.Cmd, io.ReadCloser, io.ReadCloser, error) {
 	var err error
 
 	if !strings.Contains(cmd, ".exe") {
 		e.runnerLog("CMD will not recognize non .exe file for execution, path: %s", cmd)
 	}
 	c := exec.Command("cmd", "/c", cmd)
+	c.Env = append(c.Env, envVariables...)
+
 	stderr, err := c.StderrPipe()
 	if err != nil {
 		return nil, nil, nil, err


### PR DESCRIPTION
This pull request adds a new key `env_file` to the configuration, the key specifies a file from which the environment variables for running `bin` should be sourced.  
If `env_file` is set, the environment file is sourced every time the `bin` is run, so that it works as expected when "env" is in `include_ext` and the env file is updated.

The new feature was suggested in [#47](https://github.com/cosmtrek/air/pull/47#issuecomment-652642051) and removes the need for less elegant solutions like the one suggested in [#58](https://github.com/cosmtrek/air/issues/58#issuecomment-898537034).