### PR TITLE
Make air work with Colima

### DIFF
--- a/runner/engine.go
+++ b/runner/engine.go
@@ -239,9 +239,6 @@ func (e *Engine) watchPath(path string) error {
 				return
 			case ev := <-e.watcher.Events():
 				e.mainDebug("event: %+v", ev)
-				if !validEvent(ev) {
-					break
-				}
 				if isDir(ev.Name) {
 					e.watchNewDir(ev.Name, removeEvent(ev))
 					break

--- a/runner/util.go
+++ b/runner/util.go
@@ -215,12 +215,6 @@ func isDir(path string) bool {
 	return i.IsDir()
 }
 
-func validEvent(ev fsnotify.Event) bool {
-	return ev.Op&fsnotify.Create == fsnotify.Create ||
-		ev.Op&fsnotify.Write == fsnotify.Write ||
-		ev.Op&fsnotify.Remove == fsnotify.Remove
-}
-
 func removeEvent(ev fsnotify.Event) bool {
 	return ev.Op&fsnotify.Remove == fsnotify.Remove
 }


### PR DESCRIPTION
Air probably shouldn't filter out chmod events, as they're valid filewatcher events dispatched by popular tools specifically for livereload.

This patch fixes Air when using Colima instead of Docker Desktop for Mac, as most users are moving away from Docker Desktop in favor of Colima after the licensing changes.

Related: https://github.com/abiosoft/colima/issues/261#issuecomment-1484677394

