### PR TITLE
build binaries with CGO_ENABLED=0

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,6 +9,8 @@ builds:
     ldflags:
       - -s -w -X "main.airVersion={{.Version}}"
       - -s -w -X "main.goVersion={{.Env.GOVERSION}}"
+    env:
+      - CGO_ENABLED=0
 archives:
   - id: tar.gz
     format: tar.gz


### PR DESCRIPTION
* CGO_ENABLED should be set to "0" when application running in alpine linux or it will be failed to start.