### PR TITLE
feat: Add support for YAML files

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,12 @@ You can initialize the `.air.toml` configuration file to the current directory w
 air init
 ```
 
+Alternatively, you can generate a `.air.yaml` configuration with the following command:
+
+```bash
+air init yaml
+```
+
 After this, you can just run the `air` command without additional arguments and it will use the `.air.toml` file for configuration.
 
 ```bash

--- a/air_example.yml
+++ b/air_example.yml
@@ -1,0 +1,81 @@
+# Config file for [Air](https://github.com/cosmtrek/air) in TOML format
+
+# Working directory
+# . or absolute path, please note that the directories following must be under root.
+root: .
+tmp_dir: tmp
+
+build:
+  # Just plain old shell command. You could use `make` as well.
+  cmd: go build -o ./tmp/main .
+  # Binary file yields from `cmd`.
+  bin: tmp/main
+  # Customize binary, can setup environment variables when run your app.
+  full_bin: APP_ENV=dev APP_USER=air ./tmp/main
+  # Watch these filename extensions.
+  include_ext:
+    - go
+    - tpl
+    - tmpl
+    - html
+  # Ignore these filename extensions or directories.
+  exclude_dir:
+    - assets
+    - tmp
+    - vendor
+    - frontend/node_modules
+  # Watch these directories if you specified.
+  include_dir: []
+  # Watch these files.
+  include_file: []
+  # Exclude files.
+  exclude_file: []
+  # Exclude specific regular expressions.
+  exclude_regex: _test\\.go
+  # Exclude unchanged files.
+  exclude_unchanged: true
+  # Follow symlink for directories
+  follow_symlink: true
+  # This log file places in your tmp_dir.
+  log: air.log
+  # Poll files for changes instead of using fsnotify.
+  poll: false
+  # Poll interval (defaults to the minimum interval of 500ms).
+  poll_interval: 500 # ms
+  # It's not necessary to trigger build each time file changes if it's too frequent.
+  delay: 0 # ms
+  # Stop running old binary when build errors occur.
+  stop_on_error: true
+  # Send Interrupt signal before killing process (windows does not support this feature)
+  send_interrupt: false
+  # Delay after sending Interrupt signal
+  kill_delay: 500 # ms
+  # Rerun binary or not
+  rerun: false
+  # Delay after each executions
+  rerun_delay: 500
+  # Add additional arguments when running binary (bin/full_bin). Will run './tmp/main hello world'.
+  args_bin:
+    - hello
+    - world
+
+log:
+  # Show log time
+  time: false
+  # Only show main log (silences watcher, build, runner)
+  main_only: false
+
+color:
+  # Customize each part's color. If no color found, use the raw app log.
+  main: magenta
+  watcher: cyan
+  build: yellow
+  runner: green
+
+misc:
+  # Delete tmp directory on exit
+  clean_on_exit: true
+
+screen:
+  clear_on_rebuild: true
+  keep_scroll: true

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/gohugoio/hugo v0.111.3
 	github.com/pelletier/go-toml v1.9.5
 	github.com/stretchr/testify v1.8.1
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -26,5 +27,4 @@ require (
 	golang.org/x/sys v0.5.0 // indirect
 	golang.org/x/text v0.7.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/main.go
+++ b/main.go
@@ -62,10 +62,13 @@ func main() {
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 
 	var err error
-	cfg, err := runner.InitConfig(cfgPath)
+	cfg, name, err := runner.InitConfig(cfgPath)
 	if err != nil {
 		log.Fatal(err)
 		return
+	}
+	if name != "" {
+		fmt.Printf("Using configuration: %s\n", name)
 	}
 	cfg.WithArgs(cmdArgs)
 	r, err := runner.NewEngineWithConfig(cfg, debugMode)

--- a/runner/_testdata/yaml/.air.yaml
+++ b/runner/_testdata/yaml/.air.yaml
@@ -1,0 +1,1 @@
+root: yaml_root

--- a/runner/_testdata/yml/.air.yml
+++ b/runner/_testdata/yml/.air.yml
@@ -1,0 +1,1 @@
+root: yml_root

--- a/runner/config.go
+++ b/runner/config.go
@@ -143,7 +143,7 @@ func InitConfig(path string) (cfg *Config, name string, err error) {
 	return ret, name, err
 }
 
-func writeDefaultConfig() {
+func writeDefaultConfig(mode string) {
 	confFiles := []string{dftTOML, dftYAML, dftYML, dftConf}
 
 	for _, fname := range confFiles {
@@ -158,24 +158,43 @@ func writeDefaultConfig() {
 		}
 	}
 
-	file, err := os.Create(dftTOML)
+	var fname string
+	switch mode {
+	case "yaml", "yml":
+		fname = dftYAML
+	default:
+		fname = dftTOML
+	}
+
+	file, err := os.Create(fname)
 	if err != nil {
 		log.Fatalf("failed to create a new configuration: %+v", err)
 	}
 	defer file.Close()
 
 	config := defaultConfig()
-	configFile, err := toml.Marshal(config)
-	if err != nil {
-		log.Fatalf("failed to marshal the default configuration: %+v", err)
+
+	var configFile []byte
+	switch mode {
+	case "yaml", "yml":
+		configFile, err = yaml.Marshal(config)
+		if err != nil {
+			log.Fatalf("failed to marshal the default configuration: %+v", err)
+		}
+
+	default:
+		configFile, err = toml.Marshal(config)
+		if err != nil {
+			log.Fatalf("failed to marshal the default configuration: %+v", err)
+		}
 	}
 
 	_, err = file.Write(configFile)
 	if err != nil {
-		log.Fatalf("failed to write to %s: %+v", dftTOML, err)
+		log.Fatalf("failed to write to %s: %+v", fname, err)
 	}
 
-	fmt.Printf("%s file created to the current directory with the default settings\n", dftTOML)
+	fmt.Printf("%s file created to the current directory with the default settings\n", fname)
 }
 
 func defaultPathConfig() (*Config, string, error) {

--- a/runner/config.go
+++ b/runner/config.go
@@ -13,48 +13,51 @@ import (
 
 	"dario.cat/mergo"
 	"github.com/pelletier/go-toml"
+	"gopkg.in/yaml.v3"
 )
 
 const (
 	dftTOML = ".air.toml"
+	dftYAML = ".air.yaml"
+	dftYML  = ".air.yml"
 	dftConf = ".air.conf"
 	airWd   = "air_wd"
 )
 
 // Config is the main configuration structure for Air.
 type Config struct {
-	Root        string    `toml:"root"`
-	TmpDir      string    `toml:"tmp_dir"`
-	TestDataDir string    `toml:"testdata_dir"`
-	Build       cfgBuild  `toml:"build"`
-	Color       cfgColor  `toml:"color"`
-	Log         cfgLog    `toml:"log"`
-	Misc        cfgMisc   `toml:"misc"`
-	Screen      cfgScreen `toml:"screen"`
+	Root        string    `toml:"root" yaml:"root"`
+	TmpDir      string    `toml:"tmp_dir" yaml:"tmp_dir"`
+	TestDataDir string    `toml:"testdata_dir" yaml:"testdata_dir"`
+	Build       cfgBuild  `toml:"build" yaml:"build"`
+	Color       cfgColor  `toml:"color" yaml:"color"`
+	Log         cfgLog    `toml:"log" yaml:"log"`
+	Misc        cfgMisc   `toml:"misc" yaml:"misc"`
+	Screen      cfgScreen `toml:"screen" yaml:"screen"`
 }
 
 type cfgBuild struct {
-	Cmd              string        `toml:"cmd"`
-	Bin              string        `toml:"bin"`
-	FullBin          string        `toml:"full_bin"`
-	ArgsBin          []string      `toml:"args_bin"`
-	Log              string        `toml:"log"`
-	IncludeExt       []string      `toml:"include_ext"`
-	ExcludeDir       []string      `toml:"exclude_dir"`
-	IncludeDir       []string      `toml:"include_dir"`
-	ExcludeFile      []string      `toml:"exclude_file"`
-	IncludeFile      []string      `toml:"include_file"`
-	ExcludeRegex     []string      `toml:"exclude_regex"`
-	ExcludeUnchanged bool          `toml:"exclude_unchanged"`
-	FollowSymlink    bool          `toml:"follow_symlink"`
-	Poll             bool          `toml:"poll"`
-	PollInterval     int           `toml:"poll_interval"`
-	Delay            int           `toml:"delay"`
-	StopOnError      bool          `toml:"stop_on_error"`
-	SendInterrupt    bool          `toml:"send_interrupt"`
-	KillDelay        time.Duration `toml:"kill_delay"`
-	Rerun            bool          `toml:"rerun"`
-	RerunDelay       int           `toml:"rerun_delay"`
+	Cmd              string        `toml:"cmd" yaml:"cmd"`
+	Bin              string        `toml:"bin" yaml:"bin"`
+	FullBin          string        `toml:"full_bin" yaml:"full_bin"`
+	ArgsBin          []string      `toml:"args_bin" yaml:"args_bin"`
+	Log              string        `toml:"log" yaml:"log"`
+	IncludeExt       []string      `toml:"include_ext" yaml:"include_ext"`
+	ExcludeDir       []string      `toml:"exclude_dir" yaml:"exclude_dir"`
+	IncludeDir       []string      `toml:"include_dir" yaml:"include_dir"`
+	ExcludeFile      []string      `toml:"exclude_file" yaml:"exclude_file"`
+	IncludeFile      []string      `toml:"include_file" yaml:"include_file"`
+	ExcludeRegex     []string      `toml:"exclude_regex" yaml:"exclude_regex"`
+	ExcludeUnchanged bool          `toml:"exclude_unchanged" yaml:"exclude_unchanged"`
+	FollowSymlink    bool          `toml:"follow_symlink" yaml:"follow_symlink"`
+	Poll             bool          `toml:"poll" yaml:"poll"`
+	PollInterval     int           `toml:"poll_interval" yaml:"poll_interval"`
+	Delay            int           `toml:"delay" yaml:"delay"`
+	StopOnError      bool          `toml:"stop_on_error" yaml:"stop_on_error"`
+	SendInterrupt    bool          `toml:"send_interrupt" yaml:"send_interrupt"`
+	KillDelay        time.Duration `toml:"kill_delay" yaml:"kill_delay"`
+	Rerun            bool          `toml:"rerun" yaml:"rerun"`
+	RerunDelay       int           `toml:"rerun_delay" yaml:"rerun_delay"`
 	regexCompiled    []*regexp.Regexp
 }
 
@@ -73,25 +76,25 @@ func (c *cfgBuild) RegexCompiled() ([]*regexp.Regexp, error) {
 }
 
 type cfgLog struct {
-	AddTime  bool `toml:"time"`
-	MainOnly bool `toml:"main_only"`
+	AddTime  bool `toml:"time" yaml:"time"`
+	MainOnly bool `toml:"main_only" yaml:"main_only"`
 }
 
 type cfgColor struct {
-	Main    string `toml:"main"`
-	Watcher string `toml:"watcher"`
-	Build   string `toml:"build"`
-	Runner  string `toml:"runner"`
-	App     string `toml:"app"`
+	Main    string `toml:"main" yaml:"main"`
+	Watcher string `toml:"watcher" yaml:"watcher"`
+	Build   string `toml:"build" yaml:"build"`
+	Runner  string `toml:"runner" yaml:"runner"`
+	App     string `toml:"app" yaml:"app"`
 }
 
 type cfgMisc struct {
-	CleanOnExit bool `toml:"clean_on_exit"`
+	CleanOnExit bool `toml:"clean_on_exit" yaml:"clean_on_exit"`
 }
 
 type cfgScreen struct {
-	ClearOnRebuild bool `toml:"clear_on_rebuild"`
-	KeepScroll     bool `toml:"keep_scroll"`
+	ClearOnRebuild bool `toml:"clear_on_rebuild" yaml:"clear_on_rebuild"`
+	KeepScroll     bool `toml:"keep_scroll" yaml:"keep_scroll"`
 }
 
 type sliceTransformer struct{}
@@ -109,16 +112,17 @@ func (t sliceTransformer) Transformer(typ reflect.Type) func(dst, src reflect.Va
 }
 
 // InitConfig initializes the configuration.
-func InitConfig(path string) (cfg *Config, err error) {
+func InitConfig(path string) (cfg *Config, name string, err error) {
+	name = path
 	if path == "" {
-		cfg, err = defaultPathConfig()
+		cfg, name, err = defaultPathConfig()
 		if err != nil {
-			return nil, err
+			return nil, name, err
 		}
 	} else {
 		cfg, err = readConfigOrDefault(path)
 		if err != nil {
-			return nil, err
+			return nil, name, err
 		}
 	}
 	config := defaultConfig()
@@ -132,15 +136,15 @@ func InitConfig(path string) (cfg *Config, err error) {
 		config.Overwrite = true
 	})
 	if err != nil {
-		return nil, err
+		return nil, name, err
 	}
 
 	err = ret.preprocess()
-	return ret, err
+	return ret, name, err
 }
 
 func writeDefaultConfig() {
-	confFiles := []string{dftTOML, dftConf}
+	confFiles := []string{dftTOML, dftYAML, dftYML, dftConf}
 
 	for _, fname := range confFiles {
 		fstat, err := os.Stat(fname)
@@ -174,20 +178,20 @@ func writeDefaultConfig() {
 	fmt.Printf("%s file created to the current directory with the default settings\n", dftTOML)
 }
 
-func defaultPathConfig() (*Config, error) {
-	// when path is blank, first find `.air.toml`, `.air.conf` in `air_wd` and current working directory, if not found, use defaults
-	for _, name := range []string{dftTOML, dftConf} {
+func defaultPathConfig() (*Config, string, error) {
+	// when path is blank, first find `.air.toml`, `.air.yaml`, `.air.yml`,`.air.conf` in `air_wd` and current working directory, if not found, use defaults
+	for _, name := range []string{dftTOML, dftYAML, dftYML, dftConf} {
 		cfg, err := readConfByName(name)
 		if err == nil {
 			if name == dftConf {
 				fmt.Println("`.air.conf` will be deprecated soon, recommend using `.air.toml`.")
 			}
-			return cfg, nil
+			return cfg, name, nil
 		}
 	}
 
 	dftCfg := defaultConfig()
-	return &dftCfg, nil
+	return &dftCfg, "", nil
 }
 
 func readConfByName(name string) (*Config, error) {
@@ -260,8 +264,17 @@ func readConfig(path string) (*Config, error) {
 	}
 
 	cfg := new(Config)
-	if err = toml.Unmarshal(data, cfg); err != nil {
-		return nil, err
+	ext := filepath.Ext(path)
+	switch ext {
+	case ".yml", ".yaml":
+		if err = yaml.Unmarshal(data, cfg); err != nil {
+			return nil, err
+		}
+
+	default:
+		if err = toml.Unmarshal(data, cfg); err != nil {
+			return nil, err
+		}
 	}
 
 	return cfg, nil

--- a/runner/config_test.go
+++ b/runner/config_test.go
@@ -70,38 +70,57 @@ func TestBinCmdPath(t *testing.T) {
 
 func TestDefaultPathConfig(t *testing.T) {
 	tests := []struct {
-		name string
-		path string
-		root string
+		name     string
+		path     string
+		root     string
+		filename string
 	}{{
-		name: "Invalid Path",
-		path: "invalid/path",
-		root: ".",
+		name:     "Invalid Path",
+		path:     "invalid/path",
+		root:     ".",
+		filename: "",
 	}, {
-		name: "TOML",
-		path: "_testdata/toml",
-		root: "toml_root",
+		name:     "TOML",
+		path:     "_testdata/toml",
+		root:     "toml_root",
+		filename: ".air.toml",
 	}, {
-		name: "Conf",
-		path: "_testdata/conf",
-		root: "conf_root",
+		name:     "YAML",
+		path:     "_testdata/yaml",
+		root:     "yaml_root",
+		filename: ".air.yaml",
 	}, {
-		name: "Both",
-		path: "_testdata/both",
-		root: "both_root",
+		name:     "YML",
+		path:     "_testdata/yml",
+		root:     "yml_root",
+		filename: ".air.yml",
+	}, {
+		name:     "Conf",
+		path:     "_testdata/conf",
+		root:     "conf_root",
+		filename: ".air.conf",
+	}, {
+		name:     "Both",
+		path:     "_testdata/both",
+		root:     "both_root",
+		filename: ".air.toml",
 	}}
 
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv(airWd, tt.path)
-			c, err := defaultPathConfig()
+			c, filename, err := defaultPathConfig()
 			if err != nil {
 				t.Fatalf("Should not be fail: %s.", err)
 			}
 
 			if got, want := c.Root, tt.root; got != want {
 				t.Fatalf("Root is %s, but want %s.", got, want)
+			}
+
+			if got, want := filename, tt.filename; got != want {
+				t.Fatalf("Filename is %s, but want %s.", got, want)
 			}
 		})
 	}

--- a/runner/engine.go
+++ b/runner/engine.go
@@ -79,7 +79,11 @@ func NewEngine(cfgPath string, debugMode bool) (*Engine, error) {
 // Run run run
 func (e *Engine) Run() {
 	if len(os.Args) > 1 && os.Args[1] == "init" {
-		writeDefaultConfig()
+		mode := "toml"
+		if len(os.Args) > 2 {
+			mode = os.Args[2]
+		}
+		writeDefaultConfig(mode)
 		return
 	}
 

--- a/runner/engine.go
+++ b/runner/engine.go
@@ -69,7 +69,7 @@ func NewEngineWithConfig(cfg *Config, debugMode bool) (*Engine, error) {
 // NewEngine ...
 func NewEngine(cfgPath string, debugMode bool) (*Engine, error) {
 	var err error
-	cfg, err := InitConfig(cfgPath)
+	cfg, _, err := InitConfig(cfgPath)
 	if err != nil {
 		return nil, err
 	}

--- a/runner/engine_test.go
+++ b/runner/engine_test.go
@@ -721,7 +721,7 @@ func TestRebuildWhenRunCmdUsingDLV(t *testing.T) {
 	assert.True(t, checkPortConnectionRefused(port))
 }
 
-func TestWriteDefaultConfig(t *testing.T) {
+func TestWriteDefaultTOMLConfig(t *testing.T) {
 	port, f := GetPort()
 	f()
 	t.Logf("port: %d", port)
@@ -729,7 +729,7 @@ func TestWriteDefaultConfig(t *testing.T) {
 	tmpDir := initTestEnv(t, port)
 	// change dir to tmpDir
 	chdir(t, tmpDir)
-	writeDefaultConfig()
+	writeDefaultConfig("")
 	// check the file is exist
 	if _, err := os.Stat(dftTOML); err != nil {
 		t.Fatal(err)
@@ -737,6 +737,54 @@ func TestWriteDefaultConfig(t *testing.T) {
 
 	// check the file content is right
 	actual, err := readConfig(dftTOML)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expect := defaultConfig()
+
+	assert.Equal(t, expect, *actual)
+}
+
+func TestWriteDefaultYAMLConfig(t *testing.T) {
+	port, f := GetPort()
+	f()
+	t.Logf("port: %d", port)
+
+	tmpDir := initTestEnv(t, port)
+	// change dir to tmpDir
+	chdir(t, tmpDir)
+	writeDefaultConfig("yaml")
+	// check the file is exist
+	if _, err := os.Stat(dftYAML); err != nil {
+		t.Fatal(err)
+	}
+
+	// check the file content is right
+	actual, err := readConfig(dftYAML)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expect := defaultConfig()
+
+	assert.Equal(t, expect, *actual)
+}
+
+func TestWriteDefaultYMLConfig(t *testing.T) {
+	port, f := GetPort()
+	f()
+	t.Logf("port: %d", port)
+
+	tmpDir := initTestEnv(t, port)
+	// change dir to tmpDir
+	chdir(t, tmpDir)
+	writeDefaultConfig("yml")
+	// check the file is exist
+	if _, err := os.Stat(dftYAML); err != nil {
+		t.Fatal(err)
+	}
+
+	// check the file content is right
+	actual, err := readConfig(dftYAML)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -791,7 +839,7 @@ func TestShouldIncludeGoTestFile(t *testing.T) {
 	tmpDir := initTestEnv(t, port)
 	// change dir to tmpDir
 	chdir(t, tmpDir)
-	writeDefaultConfig()
+	writeDefaultConfig("")
 
 	// write go test file
 	file, err := os.Create("main_test.go")

--- a/runner/flag_test.go
+++ b/runner/flag_test.go
@@ -125,7 +125,7 @@ func TestConfigRuntimeArgs(t *testing.T) {
 			flag := flag.NewFlagSet(t.Name(), flag.ExitOnError)
 			cmdArgs := ParseConfigFlag(flag)
 			flag.Parse(tc.args)
-			cfg, err := InitConfig("")
+			cfg, _, err := InitConfig("")
 			if err != nil {
 				log.Fatal(err)
 				return

--- a/runner/util_test.go
+++ b/runner/util_test.go
@@ -279,7 +279,7 @@ func TestCheckIncludeFile(t *testing.T) {
 	e := Engine{
 		config: &Config{
 			Build: cfgBuild{
-				IncludeFile:   []string{"main.go"},
+				IncludeFile: []string{"main.go"},
 			},
 		},
 	}


### PR DESCRIPTION
This addresses #341

I tested this with an existing config. It's also compatible with existing configs.
But since I didn't invest too much into this, let me know if I forgot anything.

Another change: At start it shows the used config file (if any).

TODO:
- [x] Support for `.air.yml` and `.air.yaml` (Default: `.air.toml`)
- [x] `air init toml`, `air init yaml` and `air init yml`