### PR TITLE
fix: Prevent duplicate processes when multiple buildRuns run simultaneously

### DIFF
--- a/runner/engine.go
+++ b/runner/engine.go
@@ -435,10 +435,6 @@ func (e *Engine) runBin() error {
 	killFunc := func(cmd *exec.Cmd, stdout io.ReadCloser, stderr io.ReadCloser, killCh chan struct{}, processExit chan struct{}, wg *sync.WaitGroup) {
 		defer wg.Done()
 		select {
-		// the process haven't exited yet, kill it
-		case <-killCh:
-			break
-
 		// listen to binStopCh
 		// cleanup() will close binStopCh when engine stop
 		// start() will close binStopCh when file changed


### PR DESCRIPTION
Hi maintainers, this PR fixes the behavior that air duplicates processses when multiple buildRuns run simultaneously.
Closes #404, Closes #421, Closes #426.

To reproduce issue:

main.go
```go
package main

import (
	"log"
	"net/http"
	"os"
)

func main() {
	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
		w.Write([]byte("Hello World!"))
	})

	log.Print(os.Getpid(), " Starting server...")
	if err := http.ListenAndServe(":8080", nil); err != nil {
		log.Fatal(os.Getpid(), err)
	}
}
```

Run `air -d` and save a file multiple times in a short period of time, then air executes multiple processes.
![air](https://github.com/cosmtrek/air/assets/81744248/799efaa4-bea8-4dd0-a74b-10fe2e41ae75)

This behavior appears from v1.41.0, and seems to be brought by the following pull request.
- #363 

I looked into what was making the difference, and it seems that the following code that was in place before the change was important.
https://github.com/cosmtrek/air/blob/d0a697adcf852559ab6fff59aa164b18f62571a0/runner/engine.go#L486-L490

This PR revive that code, and makes
- killFunc is always resumed by binStopCh close.
- killCh is for break rerun loop only.
- handle exitCh after rerun loop breaks.