### PR TITLE
Pre & Post commands 

### DIFF
--- a/air_example.toml
+++ b/air_example.toml
@@ -7,9 +7,11 @@ tmp_dir = "tmp"
 
 [build]
 # Array of commands to run before each build
-pre_cmd = ["echo \"hello air\" > test.txt"]
+pre_cmd = ["echo \"hello air\" > pre_cmd.txt"]
 # Just plain old shell command. You could use `make` as well.
 cmd = "go build -o ./tmp/main ."
+# Array of commands to run after ^C
+post_cmd = ["echo \"hello air\" > post_cmd.txt"]
 # Binary file yields from `cmd`.
 bin = "tmp/main"
 # Customize binary, can setup environment variables when run your app.

--- a/air_example.toml
+++ b/air_example.toml
@@ -7,11 +7,11 @@ tmp_dir = "tmp"
 
 [build]
 # Array of commands to run before each build
-pre_cmd = ["echo \"hello air\" > pre_cmd.txt"]
+pre_cmd = ["echo 'hello air' > pre_cmd.txt"]
 # Just plain old shell command. You could use `make` as well.
 cmd = "go build -o ./tmp/main ."
 # Array of commands to run after ^C
-post_cmd = ["echo \"hello air\" > post_cmd.txt"]
+post_cmd = ["echo 'hello air' > post_cmd.txt"]
 # Binary file yields from `cmd`.
 bin = "tmp/main"
 # Customize binary, can setup environment variables when run your app.

--- a/air_example.toml
+++ b/air_example.toml
@@ -7,7 +7,7 @@ tmp_dir = "tmp"
 
 [build]
 # Array of commands to run before each build
-pre_cmd = ["echo Hello","echo Air"]
+pre_cmd = ["echo \"hello air\" > test.txt"]
 # Just plain old shell command. You could use `make` as well.
 cmd = "go build -o ./tmp/main ."
 # Binary file yields from `cmd`.

--- a/air_example.toml
+++ b/air_example.toml
@@ -6,6 +6,8 @@ root = "."
 tmp_dir = "tmp"
 
 [build]
+# Array of commands to run before each build
+pre_cmd = ["echo Hello","echo Air"]
 # Just plain old shell command. You could use `make` as well.
 cmd = "go build -o ./tmp/main ."
 # Binary file yields from `cmd`.

--- a/runner/config.go
+++ b/runner/config.go
@@ -34,6 +34,7 @@ type Config struct {
 }
 
 type cfgBuild struct {
+	PreCmd           []string      `toml:"pre_cmd"`
 	Cmd              string        `toml:"cmd"`
 	Bin              string        `toml:"bin"`
 	FullBin          string        `toml:"full_bin"`

--- a/runner/config.go
+++ b/runner/config.go
@@ -36,6 +36,7 @@ type Config struct {
 type cfgBuild struct {
 	PreCmd           []string      `toml:"pre_cmd"`
 	Cmd              string        `toml:"cmd"`
+	PostCmd          []string      `toml:"post_cmd"`
 	Bin              string        `toml:"bin"`
 	FullBin          string        `toml:"full_bin"`
 	ArgsBin          []string      `toml:"args_bin"`

--- a/runner/config_test.go
+++ b/runner/config_test.go
@@ -15,6 +15,7 @@ const (
 
 func getWindowsConfig() Config {
 	build := cfgBuild{
+		PreCmd:       []string{"echo Hello Air"},
 		Cmd:          "go build -o ./tmp/main .",
 		Bin:          "./tmp/main",
 		Log:          "build-errors.log",

--- a/runner/engine.go
+++ b/runner/engine.go
@@ -417,6 +417,7 @@ func (e *Engine) flushEvents() {
 	}
 }
 
+// utility to execute commands, such as cmd & pre_cmd
 func (e *Engine) runCommand(command string) error {
 	cmd, stdout, stderr, err := e.startCmd(command)
 	if err != nil {
@@ -436,6 +437,7 @@ func (e *Engine) runCommand(command string) error {
 	return nil
 }
 
+// run cmd option in .air.toml
 func (e *Engine) building() error {
 	e.buildLog("building...")
 	err := e.runCommand(e.config.Build.Cmd)
@@ -445,6 +447,7 @@ func (e *Engine) building() error {
 	return nil
 }
 
+// run pre_cmd option in .air.toml
 func (e *Engine) runPreCmd() error {
 	for _, command := range e.config.Build.PreCmd {
 		e.runnerLog("> %s", command)

--- a/runner/engine.go
+++ b/runner/engine.go
@@ -378,7 +378,7 @@ func (e *Engine) buildRun() {
 	var err error
 	if err = e.runPreCmd(); err != nil {
 		e.canExit <- true
-		e.mainLog("failed to execute pre_cmd: %s", err.Error())
+		e.runnerLog("failed to execute pre_cmd: %s", err.Error())
 		if e.config.Build.StopOnError {
 			return
 		}
@@ -450,6 +450,18 @@ func (e *Engine) building() error {
 // run pre_cmd option in .air.toml
 func (e *Engine) runPreCmd() error {
 	for _, command := range e.config.Build.PreCmd {
+		e.runnerLog("> %s", command)
+		err := e.runCommand(command)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// run post_cmd option in .air.toml
+func (e *Engine) runPostCmd() error {
+	for _, command := range e.config.Build.PostCmd {
 		e.runnerLog("> %s", command)
 		err := e.runCommand(command)
 		if err != nil {
@@ -585,5 +597,8 @@ func (e *Engine) cleanup() {
 
 // Stop the air
 func (e *Engine) Stop() {
+	if err := e.runPostCmd(); err != nil {
+		e.runnerLog("failed to execute post_cmd, error: %s", err.Error())
+	}
 	close(e.exitCh)
 }

--- a/runner/engine_test.go
+++ b/runner/engine_test.go
@@ -185,6 +185,17 @@ func TestRerunWhenFileChanged(t *testing.T) {
 	}
 }
 
+func TestRunPreCmd(t *testing.T) {
+	engine, err := NewEngine("", true)
+	if err != nil {
+		t.Fatalf("Should not be fail: %s.", err)
+	}
+	err = engine.runPreCmd()
+	if err != nil {
+		t.Fatalf("Should not be fail: %s.", err)
+	}
+}
+
 func TestRunBin(t *testing.T) {
 	engine, err := NewEngine("", true)
 	if err != nil {

--- a/runner/engine_test.go
+++ b/runner/engine_test.go
@@ -186,17 +186,36 @@ func TestRerunWhenFileChanged(t *testing.T) {
 }
 
 func TestRunCommand(t *testing.T) {
+	// generate a random port
+	port, f := GetPort()
+	f()
+	t.Logf("port: %d", port)
+	tmpDir := initTestEnv(t, port)
+	// change dir to tmpDir
+	chdir(t, tmpDir)
 	engine, err := NewEngine("", true)
 	if err != nil {
 		t.Fatalf("Should not be fail: %s.", err)
 	}
-	err = engine.runCommand("echo Hello Air")
+	err = engine.runCommand("touch test.txt")
 	if err != nil {
 		t.Fatalf("Should not be fail: %s.", err)
+	}
+	if _, err := os.Stat("./test.txt"); err != nil {
+		if os.IsNotExist(err) {
+			t.Fatalf("Should not be fail: %s.", err)
+		}
 	}
 }
 
 func TestRunPreCmd(t *testing.T) {
+	// generate a random port
+	port, f := GetPort()
+	f()
+	t.Logf("port: %d", port)
+	tmpDir := initTestEnv(t, port)
+	// change dir to tmpDir
+	chdir(t, tmpDir)
 	engine, err := NewEngine("", true)
 	if err != nil {
 		t.Fatalf("Should not be fail: %s.", err)
@@ -204,6 +223,11 @@ func TestRunPreCmd(t *testing.T) {
 	err = engine.runPreCmd()
 	if err != nil {
 		t.Fatalf("Should not be fail: %s.", err)
+	}
+	if _, err := os.Stat("./test.txt"); err != nil {
+		if os.IsNotExist(err) {
+			t.Fatalf("Should not be fail: %s.", err)
+		}
 	}
 }
 

--- a/runner/engine_test.go
+++ b/runner/engine_test.go
@@ -224,7 +224,33 @@ func TestRunPreCmd(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Should not be fail: %s.", err)
 	}
-	if _, err := os.Stat("./test.txt"); err != nil {
+	if _, err := os.Stat("./pre_cmd.txt"); err != nil {
+		if os.IsNotExist(err) {
+			t.Fatalf("Should not be fail: %s.", err)
+		}
+	}
+}
+
+func TestRunPostCmd(t *testing.T) {
+	// generate a random port
+	port, f := GetPort()
+	f()
+	t.Logf("port: %d", port)
+	tmpDir := initTestEnv(t, port)
+	// change dir to tmpDir
+	chdir(t, tmpDir)
+
+	engine, err := NewEngine("", true)
+	if err != nil {
+		t.Fatalf("Should not be fail: %s.", err)
+	}
+
+	err = engine.runPostCmd()
+	if err != nil {
+		t.Fatalf("Should not be fail: %s.", err)
+	}
+
+	if _, err := os.Stat("./post_cmd.txt"); err != nil {
 		if os.IsNotExist(err) {
 			t.Fatalf("Should not be fail: %s.", err)
 		}

--- a/runner/engine_test.go
+++ b/runner/engine_test.go
@@ -185,6 +185,17 @@ func TestRerunWhenFileChanged(t *testing.T) {
 	}
 }
 
+func TestRunCommand(t *testing.T) {
+	engine, err := NewEngine("", true)
+	if err != nil {
+		t.Fatalf("Should not be fail: %s.", err)
+	}
+	err = engine.runCommand("echo Hello Air")
+	if err != nil {
+		t.Fatalf("Should not be fail: %s.", err)
+	}
+}
+
 func TestRunPreCmd(t *testing.T) {
 	engine, err := NewEngine("", true)
 	if err != nil {


### PR DESCRIPTION
closes #453 
## New Features
- A new option `pre_cmd` is added to `.air.toml`
- A new option `post_cmd` is added to `.air.tom`

## New behavior
- commands that are in `pre_cmd` will be executed one by one before each build
- commands that are in `post_cmd` will be executed upon exiting (i.e. upon hitting ^C)