### PR TITLE
Interpret value of kill_delay as milliseconds

### DIFF
--- a/runner/config.go
+++ b/runner/config.go
@@ -340,6 +340,17 @@ func (c *Config) rerunDelay() time.Duration {
 	return time.Duration(c.Build.RerunDelay) * time.Millisecond
 }
 
+func (c *Config) killDelay() time.Duration {
+	// kill_delay can be specified as an integer or duration string
+	// interpret as milliseconds if less than the value of 1 millisecond
+	if c.Build.KillDelay < time.Millisecond {
+		return c.Build.KillDelay * time.Millisecond
+	} else {
+		// normalize kill delay to milliseconds
+		return time.Duration(c.Build.KillDelay.Milliseconds()) * time.Millisecond
+	}
+}
+
 func (c *Config) binPath() string {
 	return filepath.Join(c.Root, c.Build.Bin)
 }

--- a/runner/config_test.go
+++ b/runner/config_test.go
@@ -6,6 +6,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 )
 
 const (
@@ -168,6 +169,33 @@ func TestReadConfigWithWrongPath(t *testing.T) {
 	}
 	if c != nil {
 		t.Fatal("expect is nil but got a conf")
+	}
+}
+
+func TestKillDelay(t *testing.T) {
+	config := Config{
+		Build: cfgBuild{
+			KillDelay: 1000,
+		},
+	}
+	if config.killDelay() != (1000 * time.Millisecond) {
+		t.Fatal("expect KillDelay 1000 to be interpreted as 1000 milliseconds, got ", config.killDelay())
+	}
+	config.Build.KillDelay = 1
+	if config.killDelay() != (1 * time.Millisecond) {
+		t.Fatal("expect KillDelay 1 to be interpreted as 1 millisecond, got ", config.killDelay())
+	}
+	config.Build.KillDelay = 1_000_000
+	if config.killDelay() != (1 * time.Millisecond) {
+		t.Fatal("expect KillDelay 1_000_000 to be interpreted as 1 millisecond, got ", config.killDelay())
+	}
+	config.Build.KillDelay = 100_000_000
+	if config.killDelay() != (100 * time.Millisecond) {
+		t.Fatal("expect KillDelay 100_000_000 to be interpreted as 100 milliseconds, got ", config.killDelay())
+	}
+	config.Build.KillDelay = 0
+	if config.killDelay() != 0 {
+		t.Fatal("expect KillDelay 0 to be interpreted as 0, got ", config.killDelay())
 	}
 }
 

--- a/runner/util_linux.go
+++ b/runner/util_linux.go
@@ -17,7 +17,7 @@ func (e *Engine) killCmd(cmd *exec.Cmd) (pid int, err error) {
 		if err = syscall.Kill(-pid, syscall.SIGINT); err != nil {
 			return
 		}
-		time.Sleep(e.config.Build.KillDelay)
+		time.Sleep(e.config.killDelay())
 	}
 
 	// https://stackoverflow.com/questions/22470193/why-wont-go-kill-a-child-process-correctly

--- a/runner/util_unix.go
+++ b/runner/util_unix.go
@@ -18,7 +18,7 @@ func (e *Engine) killCmd(cmd *exec.Cmd) (pid int, err error) {
 		if err = syscall.Kill(-pid, syscall.SIGINT); err != nil {
 			return
 		}
-		time.Sleep(e.config.Build.KillDelay)
+		time.Sleep(e.config.killDelay())
 	}
 	// https://stackoverflow.com/questions/22470193/why-wont-go-kill-a-child-process-correctly
 	err = syscall.Kill(-pid, syscall.SIGKILL)


### PR DESCRIPTION
`kill_delay` is parsed as a Duration ([ref](https://github.com/cosmtrek/air/blob/af962ce3f6f1a048642d5c70f97aa525792b6489/runner/config.go#L55)). When given as an integer (as in the [example config](https://github.om/cosmtrek/air/blob/af962ce3f6f1a048642d5c70f97aa525792b6489/air_example.toml#L44)), it is interpreted as nanoseconds, not milliseconds. The sleep will be too short to allow a program to respond to the interrupt and stop cleanly. This change allows the number to be interpreted as milliseconds.

This change is made to preserve backwards compatibility. If the value is specified as an value under 1 millisecond/1 000 000 nanoseconds, like `500` in the example config, the value will be interpreted as the number of milliseconds. For users who figured out that you may specify the time as a duration string like `”2s”` or use large nanosecond integers like `2000000000` for 2 seconds, the behavior will remain the same.

An alternative is changing `kill_delay` to be parsed as an integer, like `delay` and `rerun_delay`. This will break users who used duration strings or large numbers.

This may be the root cause of the problem reported in #216, as a sufficient value for `kill_delay` to allow a program to stop gracefully solved this problem for me.