### PR TITLE
Add Podman/Docker container control like app with function in the shellrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ docker run -it --rm \
 cd /go/src/github.com/cosmtrek/hub
 AIR_PORT=8080 air -c "config.toml"
 ```
-this will replace `$PWD` with the current directory, `$AIR_PORT` is the port where to public and `$@` is to accept arguments of the aplication itself for example -c
+this will replace `$PWD` with the current directory, `$AIR_PORT` is the port where to publish and `$@` is to accept arguments of the aplication itself for example -c
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -60,12 +60,12 @@ With go 1.18 or higher:
 go install github.com/cosmtrek/air@latest
 ```
 
-### Docker
+### Docker/Podman
 
 Please pull this docker image [cosmtrek/air](https://hub.docker.com/r/cosmtrek/air).
 
 ```bash
-docker run -it --rm \
+docker/podman run -it --rm \
     -w "<PROJECT>" \
     -e "air_wd=<PROJECT>" \
     -v $(pwd):<PROJECT> \
@@ -73,11 +73,22 @@ docker run -it --rm \
     cosmtrek/air
     -c <CONF>
 ```
+#### Docker/Podman .${SHELL}rc
+
+if you want to use air continuously like a normal app, you can create a function in your ${SHELL}rc (bash,zsh,etc...)
+```bash
+air() {
+    podman/docker run -it --rm \
+        -w "$PWD" -v "$PWD":"$PWD" \
+        -p "$AIR_PORT":"$AIR_PORT" \
+        docker.io/cosmtrek/air "$@"
+}
+```
 
 <details>
   <summary>For example</summary>
 
-One of my project runs in docker:
+- One of my project runs in docker:
 
 ```bash
 docker run -it --rm \
@@ -86,6 +97,13 @@ docker run -it --rm \
     -p 9090:9090 \
     cosmtrek/air
 ```
+- Another example:
+```bash
+cd /go/src/github.com/cosmtrek/hub
+AIR_PORT=8080 air -c "config.toml"
+```
+this will replace `$PWD` with the current directory, `$AIR_PORT` is the port where to public and `$@` is to accept arguments of the aplication itself for example -c
+
 </details>
 
 ## Usage


### PR DESCRIPTION
Hello,

This allows the user/dev to use `air` in a more practical way in a rootless (while using podman) dev environment.

```
air() {
    podman run -it --rm \
        -w "$PWD" -v "$PWD":"$PWD" \
        -p "$AIR_PORT":"$AIR_PORT" \
        docker.io/cosmtrek/air "$@"
}
```

you add this piece of code in .bashrc of example, then run the code:
`AIR_PORT=8080 air init ` > this will create the .air.toml

`AIR_PORT=8080 air -c .ait.toml` this will run the .air.toml created by the init.