### PR TITLE
fallback to buildinfo when airversion and goversion is empty

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,6 +6,8 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"runtime"
+	"runtime/debug"
 	"syscall"
 
 	"github.com/cosmtrek/air/runner"
@@ -43,13 +45,38 @@ func parseFlag(args []string) {
 	flag.CommandLine.Parse(args)
 }
 
+type versionInfo struct {
+	airVersion string
+	goVersion  string
+}
+
+func GetVersionInfo() versionInfo {
+	if len(airVersion) != 0 && len(goVersion) != 0 {
+		return versionInfo{
+			airVersion: airVersion,
+			goVersion:  goVersion,
+		}
+	}
+	if info, ok := debug.ReadBuildInfo(); ok {
+		return versionInfo{
+			airVersion: info.Main.Version,
+			goVersion:  runtime.Version(),
+		}
+	}
+	return versionInfo{
+		airVersion: "(unknown)",
+		goVersion:  runtime.Version(),
+	}
+}
+
 func main() {
+	versionInfo := GetVersionInfo()
 	fmt.Printf(`
   __    _   ___  
  / /\  | | | |_) 
 /_/--\ |_| |_| \_ %s, built with Go %s
 
-`, airVersion, goVersion)
+`, versionInfo.airVersion, versionInfo.goVersion)
 
 	if showVersion {
 		return

--- a/runner/config.go
+++ b/runner/config.go
@@ -214,6 +214,8 @@ func defaultConfig() Config {
 		Log:          "build-errors.log",
 		IncludeExt:   []string{"go", "tpl", "tmpl", "html"},
 		IncludeDir:   []string{},
+		PreCmd:       []string{},
+		PostCmd:      []string{},
 		ExcludeFile:  []string{},
 		IncludeFile:  []string{},
 		ExcludeDir:   []string{"assets", "tmp", "vendor", "testdata"},

--- a/version.go
+++ b/version.go
@@ -1,4 +1,6 @@
 package main
 
-var airVersion string
-var goVersion string
+var (
+	airVersion string
+	goVersion  string
+)


### PR DESCRIPTION
close https://github.com/cosmtrek/air/issues/434