### PR TITLE
refactor: refactor test functions and remove unused variables

### DIFF
--- a/main.go
+++ b/main.go
@@ -41,7 +41,9 @@ func parseFlag(args []string) {
 	flag.BoolVar(&showVersion, "v", false, "show version")
 	cmd := flag.CommandLine
 	cmdArgs = runner.ParseConfigFlag(cmd)
-	_ = flag.CommandLine.Parse(args)
+	if err := flag.CommandLine.Parse(args); err != nil {
+		log.Fatal(err)
+	}
 }
 
 type versionInfo struct {

--- a/main.go
+++ b/main.go
@@ -18,7 +18,6 @@ var (
 	debugMode   bool
 	showVersion bool
 	cmdArgs     map[string]runner.TomlInfo
-	runArgs     []string
 )
 
 func helpMessage() {
@@ -42,7 +41,7 @@ func parseFlag(args []string) {
 	flag.BoolVar(&showVersion, "v", false, "show version")
 	cmd := flag.CommandLine
 	cmdArgs = runner.ParseConfigFlag(cmd)
-	flag.CommandLine.Parse(args)
+	_ = flag.CommandLine.Parse(args)
 }
 
 type versionInfo struct {

--- a/runner/config_test.go
+++ b/runner/config_test.go
@@ -39,7 +39,6 @@ func getWindowsConfig() Config {
 }
 
 func TestBinCmdPath(t *testing.T) {
-
 	var err error
 
 	c := getWindowsConfig()
@@ -144,7 +143,9 @@ func TestConfigWithRuntimeArgs(t *testing.T) {
 
 	t.Run("when using bin", func(t *testing.T) {
 		df := defaultConfig()
-		df.preprocess()
+		if err := df.preprocess(); err != nil {
+			t.Fatalf("preprocess error %v", err)
+		}
 
 		if !contains(df.Build.ArgsBin, runtimeArg) {
 			t.Fatalf("missing expected runtime arg: %s", runtimeArg)
@@ -154,7 +155,9 @@ func TestConfigWithRuntimeArgs(t *testing.T) {
 	t.Run("when using full_bin", func(t *testing.T) {
 		df := defaultConfig()
 		df.Build.FullBin = "./tmp/main"
-		df.preprocess()
+		if err := df.preprocess(); err != nil {
+			t.Fatalf("preprocess error %v", err)
+		}
 
 		if !contains(df.Build.ArgsBin, runtimeArg) {
 			t.Fatalf("missing expected runtime arg: %s", runtimeArg)

--- a/runner/engine_test.go
+++ b/runner/engine_test.go
@@ -3,7 +3,6 @@ package runner
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net"
 	"os"
@@ -387,7 +386,9 @@ func TestCtrlCWhenHaveKillDelay(t *testing.T) {
 	engine.config.Build.KillDelay = c.Build.KillDelay
 	engine.config.Build.Delay = 2000
 	engine.config.Build.SendInterrupt = true
-	engine.config.preprocess()
+	if err := engine.config.preprocess(); err != nil {
+		t.Fatalf("Should not be fail: %s.", err)
+	}
 
 	go func() {
 		engine.Run()
@@ -845,7 +846,7 @@ exclude_file = ["main.go"]
 include_file = ["test/not_a_test.go"]
 
 `
-	if err := ioutil.WriteFile(dftTOML, []byte(config), 0o644); err != nil {
+	if err := os.WriteFile(dftTOML, []byte(config), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	engine, err := NewEngine(".air.toml", true)
@@ -980,7 +981,7 @@ include_ext = ["sh"]
 include_dir = ["nonexist"] # prevent default "." watch from taking effect
 include_file = ["main.sh"]
 `
-	if err := ioutil.WriteFile(dftTOML, []byte(config), 0o644); err != nil {
+	if err := os.WriteFile(dftTOML, []byte(config), 0o644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/runner/flag_test.go
+++ b/runner/flag_test.go
@@ -54,7 +54,7 @@ func TestFlag(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			flag := flag.NewFlagSet(t.Name(), flag.ExitOnError)
 			cmdArgs := ParseConfigFlag(flag)
-			_ = flag.Parse(tc.args)
+			assert.NoError(t, flag.Parse(tc.args))
 			assert.Equal(t, tc.expected, *cmdArgs[tc.key].Value)
 		})
 	}
@@ -121,7 +121,7 @@ func TestConfigRuntimeArgs(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			dir := t.TempDir()
-			_ = os.Chdir(dir)
+			assert.NoError(t, os.Chdir(dir))
 			flag := flag.NewFlagSet(t.Name(), flag.ExitOnError)
 			cmdArgs := ParseConfigFlag(flag)
 			_ = flag.Parse(tc.args)

--- a/runner/flag_test.go
+++ b/runner/flag_test.go
@@ -54,7 +54,7 @@ func TestFlag(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			flag := flag.NewFlagSet(t.Name(), flag.ExitOnError)
 			cmdArgs := ParseConfigFlag(flag)
-			flag.Parse(tc.args)
+			_ = flag.Parse(tc.args)
 			assert.Equal(t, tc.expected, *cmdArgs[tc.key].Value)
 		})
 	}
@@ -121,10 +121,10 @@ func TestConfigRuntimeArgs(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			dir := t.TempDir()
-			os.Chdir(dir)
+			_ = os.Chdir(dir)
 			flag := flag.NewFlagSet(t.Name(), flag.ExitOnError)
 			cmdArgs := ParseConfigFlag(flag)
-			flag.Parse(tc.args)
+			_ = flag.Parse(tc.args)
 			cfg, err := InitConfig("")
 			if err != nil {
 				log.Fatal(err)

--- a/runner/util_test.go
+++ b/runner/util_test.go
@@ -3,7 +3,6 @@ package runner
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -206,7 +205,9 @@ func Test_killCmd_SendInterrupt_false(t *testing.T) {
 			pid int
 			cmd *exec.Cmd
 		}{pid: pid, cmd: cmd}
-		cmd.Wait()
+		if err := cmd.Wait(); err != nil {
+			t.Errorf("failed to wait command: %v", err)
+		}
 		t.Logf("wait finished")
 	}()
 	resp := <-startChan
@@ -220,7 +221,7 @@ func Test_killCmd_SendInterrupt_false(t *testing.T) {
 	t.Logf("%v was been killed", pid)
 	// check processes were being killed
 	// read pids from file
-	bytesRead, _ := ioutil.ReadFile("pid")
+	bytesRead, _ := os.ReadFile("pid")
 	lines := strings.Split(string(bytesRead), "\n")
 	for _, line := range lines {
 		_, err := strconv.Atoi(line)
@@ -279,7 +280,7 @@ func TestCheckIncludeFile(t *testing.T) {
 	e := Engine{
 		config: &Config{
 			Build: cfgBuild{
-				IncludeFile:   []string{"main.go"},
+				IncludeFile: []string{"main.go"},
 			},
 		},
 	}

--- a/runner/util_test.go
+++ b/runner/util_test.go
@@ -221,7 +221,8 @@ func Test_killCmd_SendInterrupt_false(t *testing.T) {
 	t.Logf("%v was been killed", pid)
 	// check processes were being killed
 	// read pids from file
-	bytesRead, _ := os.ReadFile("pid")
+	bytesRead, err := os.ReadFile("pid")
+	assert.NoError(t, err)
 	lines := strings.Split(string(bytesRead), "\n")
 	for _, line := range lines {
 		_, err := strconv.Atoi(line)


### PR DESCRIPTION
- Remove the `runArgs` variable
- Change the way `flag.CommandLine.Parse` is called
- Modify the `TestBinCmdPath` function
- Modify the `TestConfigWithRuntimeArgs` function
- Modify the `TestCtrlCWhenHaveKillDelay` function
- Modify the `include_file` value in the `TestCtrlCWhenHaveKillDelay` function
- Modify the `include_file` value in the `TestConfigRuntimeArgs` function
- Modify the `TestFlag` function
- Modify the `TestConfigRuntimeArgs` function
- Modify the `Test_killCmd_SendInterrupt_false` function
- Modify the `bytesRead` variable in the `Test_killCmd_SendInterrupt_false` function

also fix https://github.com/cosmtrek/air/pull/439