### PR TITLE
fix: close the `e.canExit` channel in the `start` function

### DIFF
--- a/runner/engine.go
+++ b/runner/engine.go
@@ -317,6 +317,7 @@ func (e *Engine) start() {
 		select {
 		case <-e.exitCh:
 			e.mainDebug("exit in start")
+			close(e.canExit)
 			return
 		case filename = <-e.eventCh:
 			if !e.isIncludeExt(filename) {


### PR DESCRIPTION
## Resolve

- Add a line to close the `e.canExit` channel in the `start` function

## Reproduce

main.go

```go
package main

import "log"

func main() {
	log.Println("Hello World")
}
```

![image](https://github.com/cosmtrek/air/assets/21979/4bdde4c8-9ba2-4d5c-b185-6aeaf255ba3f)

Unable to terminate the process.


