### PR TITLE
Revert "fix: close the `e.canExit` channel in the `start` function (#…

### DIFF
--- a/runner/engine.go
+++ b/runner/engine.go
@@ -317,7 +317,6 @@ func (e *Engine) start() {
 		select {
 		case <-e.exitCh:
 			e.mainDebug("exit in start")
-			close(e.canExit)
 			return
 		case filename = <-e.eventCh:
 			if !e.isIncludeExt(filename) {


### PR DESCRIPTION
…477)"

This reverts commit 8a22712671b5d21895fa841bcce2745a18e54363.