### PR TITLE
chore: update GitHub Actions versions in build and release workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: build
 on:
   push:
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   build:
@@ -14,20 +14,20 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: setup Go 1.21
         id: go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: ^1.21
       - name: build
         run: make build
       - name: install dependency
-        run:  if [ $(uname) == "Darwin" ]; then brew install gnu-sed ;fi
+        run: if [ $(uname) == "Darwin" ]; then brew install gnu-sed ;fi
       - name: run Unit tests.
         run: go install github.com/go-delve/delve/cmd/dlv@latest && go test  ./... -v -covermode=count -coverprofile=coverage.txt
       - name: upload Coverage report to CodeCov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.txt
@@ -39,17 +39,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
       - name: set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
       - name: login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           push: true
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: release
 on:
   push:
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   release:
@@ -33,17 +33,17 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v3
       - name: set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v3
       - name: login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: push to docker hub
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           push: true
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -2,17 +2,18 @@ name: smoke_test
 
 on:
   push:
+  pull_request:
 
 jobs:
   smoke_test_ubuntu:
     uses: cosmtrek/air/.github/workflows/smoke_test_reuse_job.yml@add_smoke_test
-    with: 
+    with:
       run_on: ubuntu-latest
   smoke_test_macos:
     uses: cosmtrek/air/.github/workflows/smoke_test_reuse_job.yml@add_smoke_test
-    with: 
+    with:
       run_on: macos-latest
   smoke_test_windows:
     uses: cosmtrek/air/.github/workflows/smoke_test_window_reust_job.yml@fix_window_arg_bug
-    with: 
+    with:
       run_on: windows-latest

--- a/.github/workflows/smoke_test_reuse_job.yml
+++ b/.github/workflows/smoke_test_reuse_job.yml
@@ -24,7 +24,7 @@ jobs:
       - name: check rebuild
         id: check_rebuild
         working-directory: ./smoke_test/check_rebuild
-        run: | 
+        run: |
           nohup air > nohup.out 2> nohup.err < /dev/null &
           sleep 15
           echo "" >> main.go

--- a/.github/workflows/smoke_test_window_reust_job.yml
+++ b/.github/workflows/smoke_test_window_reust_job.yml
@@ -31,8 +31,8 @@ jobs:
       - name: check rebuild
         id: check_rebuild
         working-directory: ./smoke_test
-        run: | 
-           python smoke_test.py
+        run: |
+          python smoke_test.py
       - uses: nick-invision/assert-action@v1
         with:
           expected: "PASS"


### PR DESCRIPTION
- Update the version of `actions/checkout` from `v2` to `v4` in `.github/workflows/build.yml`
- Update the version of `actions/setup-go` from `v2` to `v4` in `.github/workflows/build.yml`
- Update the version of `codecov/codecov-action` from `v2` to `v3` in `.github/workflows/build.yml`
- Update the version of `docker/setup-qemu-action` from `v1` to `v3` in `.github/workflows/build.yml`
- Update the version of `docker/setup-buildx-action` from `v1` to `v3` in `.github/workflows/build.yml`
- Update the version of `docker/login-action` from `v1` to `v3` in `.github/workflows/build.yml`
- Update the version of `docker/build-push-action` from `v2` to `v5` in `.github/workflows/build.yml`

Enable testing in Pull Request event.