### PR TITLE
Fix liting; use golangci lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,16 @@
+run:
+  timeout: 2m
+
+linters:
+  disable-all: true
+  enable:
+    - errcheck # Errcheck is a program for checking for unchecked errors in go programs.
+    - gci # Gci controls Go package import order and makes it always deterministic
+    - goimports # checks that goimports was run
+    - ineffassign # Detects when assignments to existing variables are not used
+    - misspell # spell checker
+    - revive # configurable linter for Go. Drop-in replacement of golint
+    - staticcheck # go vet on steroids
+    - stylecheck # static analysis, finds bugs and performance issues, offers simplifications, and enforces style rules
+    - unconvert # Remove unnecessary type conversions
+    - unused # Checks Go code for unused constants, variables, functions and types

--- a/Makefile
+++ b/Makefile
@@ -4,14 +4,20 @@ LDFLAGS += -X "main.airVersion=$(AIRVER)"
 LDFLAGS += -X "main.goVersion=$(shell go version | sed -r 's/go version go(.*)\ .*/\1/')"
 
 GO := GO111MODULE=on CGO_ENABLED=0 go
+GOLANGCI_LINT_VERSION = 1.55.2
 
 .PHONY: init
-init:
-	go install golang.org/x/lint/golint@latest
+init: install-golangci-lint
 	go install golang.org/x/tools/cmd/goimports@latest
 	@echo "Install pre-commit hook"
 	@ln -s $(shell pwd)/hooks/pre-commit $(shell pwd)/.git/hooks/pre-commit || true
 	@chmod +x ./hack/check.sh
+
+.PHONY: install-golangci-lint
+install-golangci-lint:
+ifeq (, $(shell which golangci-lintx))
+	@$(shell curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(GOPATH)/bin $(GOLANGCI_LINT_VERSION))
+endif
 
 .PHONY: setup
 setup: init

--- a/hack/check.sh
+++ b/hack/check.sh
@@ -8,9 +8,9 @@ exit_code=0
 check_scope=$1
 if [[ "${check_scope}" = "all" ]]; then
     echo "all"
-    files=($(git ls-files | grep "\.go" | grep -v -e "^third_party" -e "^vendor"))
+    files=($(git ls-files | grep "\.go$" | grep -v -e "^third_party" -e "^vendor"))
 else
-    files=($(git diff --cached --name-only --diff-filter ACM | grep "\.go" | grep -v -e "^third_party" -e "^vendor"))
+    files=($(git diff --cached --name-only --diff-filter ACM | grep "\.go$" | grep -v -e "^third_party" -e "^vendor"))
 fi
 
 echo -e "${green}1. Formatting code style"
@@ -19,13 +19,12 @@ if [[ "${#files[@]}" -ne 0 ]]; then
 fi
 
 echo -e "${green}2. Linting"
-for file in "${files[@]}"; do
-    out=$(golint ${file})
-    if [[ -n "${out}" ]]; then
-        echo "${red}${out}"
-        exit_code=1
-    fi
-done
+out=$(golangci-lint run)
+if [[ -n "${out}" ]]; then
+    echo "${red}${out}"
+    exit_code=1
+fi
+
 
 if [[ ${exit_code} -ne 0 ]]; then
     echo "${red}Please fix the errors above :)"

--- a/main.go
+++ b/main.go
@@ -51,7 +51,7 @@ type versionInfo struct {
 	goVersion  string
 }
 
-func GetVersionInfo() versionInfo {
+func GetVersionInfo() versionInfo { //revive:disable:unexported-return
 	if len(airVersion) != 0 && len(goVersion) != 0 {
 		return versionInfo{
 			airVersion: airVersion,

--- a/runner/util_test.go
+++ b/runner/util_test.go
@@ -237,6 +237,7 @@ func Test_killCmd_SendInterrupt_false(t *testing.T) {
 func TestGetStructureFieldTagMap(t *testing.T) {
 	c := Config{}
 	tagMap := flatConfig(c)
+	assert.NotEmpty(t, tagMap)
 	for _, i2 := range tagMap {
 		fmt.Printf("%v\n", i2.fieldPath)
 	}


### PR DESCRIPTION
crurrently when updating `main.go` or by running `hack/check.sh all`

- _errors_ with 
```
main.go:54:1: comment on exported function GetVersionInfo should be of the form "GetVersionInfo ..."
main.go:55:23: exported func GetVersionInfo returns unexported type main.versionInfo, which can be annoying to use
Please fix the errors above :)
```
- noisy - unrelated YAML _wanings_  (`.go` prefix)
```
.goreleaser.yml:2:9: illegal label declaration
.goreleaser.yml:3:7: expected ';', found '-'
.goreleaser.yml:19:2: expected '}', found 'EOF'
...
```

this MR is to confirm
- if like to include  [golangci/golangci-lint](https://github.com/golangci/golangci-lint) in the context of deprecated golint is frozen/deprecated https://github.com/golang/go/issues/38968 
- or keep as is, just update `func GetVersionInfo() versionInfo` to  export as `VersionInfo`  and `hack/check.sh`
```diff
-".go"
+".go$"
```