### PR TITLE
Add live proxy feature

### DIFF
--- a/air_example.toml
+++ b/air_example.toml
@@ -73,3 +73,9 @@ clean_on_exit = true
 [screen]
 clear_on_rebuild = true
 keep_scroll = true
+
+# Enable live-reloading on the browser.
+[proxy]
+  enabled = true
+  proxy_port = 8090
+  app_port = 8080

--- a/runner/config.go
+++ b/runner/config.go
@@ -31,6 +31,7 @@ type Config struct {
 	Log         cfgLog    `toml:"log"`
 	Misc        cfgMisc   `toml:"misc"`
 	Screen      cfgScreen `toml:"screen"`
+	Proxy       cfgProxy  `toml:"proxy"`
 }
 
 type cfgBuild struct {
@@ -94,6 +95,12 @@ type cfgMisc struct {
 type cfgScreen struct {
 	ClearOnRebuild bool `toml:"clear_on_rebuild"`
 	KeepScroll     bool `toml:"keep_scroll"`
+}
+
+type cfgProxy struct {
+	Enabled   bool `toml:"enabled"`
+	ProxyPort int  `toml:"proxy_port"`
+	AppPort   int  `toml:"app_port"`
 }
 
 type sliceTransformer struct{}
@@ -350,10 +357,9 @@ func (c *Config) killDelay() time.Duration {
 	// interpret as milliseconds if less than the value of 1 millisecond
 	if c.Build.KillDelay < time.Millisecond {
 		return c.Build.KillDelay * time.Millisecond
-	} else {
-		// normalize kill delay to milliseconds
-		return time.Duration(c.Build.KillDelay.Milliseconds()) * time.Millisecond
 	}
+	// normalize kill delay to milliseconds
+	return time.Duration(c.Build.KillDelay.Milliseconds()) * time.Millisecond
 }
 
 func (c *Config) binPath() string {

--- a/runner/engine_test.go
+++ b/runner/engine_test.go
@@ -927,6 +927,9 @@ func Test(t *testing.T) {
 	t.Log("testing")
 }
 `)
+	if err != nil {
+		t.Fatal(err)
+	}
 	// run sed
 	// check the file is exist
 	if _, err := os.Stat(dftTOML); err != nil {

--- a/runner/proxy.go
+++ b/runner/proxy.go
@@ -1,0 +1,157 @@
+package runner
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+type Reloader interface {
+	AddSubscriber() *Subscriber
+	RemoveSubscriber(id int)
+	Reload()
+	Stop()
+}
+
+type Proxy struct {
+	server *http.Server
+	config *cfgProxy
+	stream Reloader
+}
+
+func NewProxy(cfg *cfgProxy) *Proxy {
+	p := &Proxy{
+		config: cfg,
+		server: &http.Server{
+			Addr: fmt.Sprintf(":%d", cfg.ProxyPort),
+		},
+		stream: NewProxyStream(),
+	}
+	return p
+}
+
+func (p *Proxy) Run() {
+	http.HandleFunc("/", p.proxyHandler)
+	http.HandleFunc("/internal/reload", p.reloadHandler)
+	if err := p.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		log.Fatal(err)
+	}
+}
+
+func (p *Proxy) Stop() {
+	p.server.Close()
+	p.stream.Stop()
+}
+
+func (p *Proxy) Reload() {
+	p.stream.Reload()
+}
+
+func (p *Proxy) injectLiveReload(origURL string, respBody io.ReadCloser) string {
+	buf := new(bytes.Buffer)
+	if _, err := buf.ReadFrom(respBody); err != nil {
+		log.Fatalf("failed to convert request body to bytes buffer, err: %+v\n", err)
+	}
+	s := buf.String()
+
+	body := strings.LastIndex(s, "</body>")
+	if body == -1 {
+		log.Fatal("invalid html page, missing the body tag")
+	}
+	script := `
+	<script>
+	const parser = new DOMParser();
+	const proxyURL = "http://localhost:%d";
+	new EventSource(proxyURL + "/internal/reload").onmessage = () => {
+		fetch(proxyURL + "%s").then(res => res.text()).then(resStr => {
+			const newPage = parser.parseFromString(resStr, "text/html");
+			document.replaceChild(newPage.documentElement, document.documentElement);
+		});
+	};
+	</script>
+	`
+	parsedScript := fmt.Sprintf(script, p.config.ProxyPort, origURL)
+
+	s = s[:body] + parsedScript + s[body:]
+	return s
+}
+
+func (p *Proxy) proxyHandler(w http.ResponseWriter, r *http.Request) {
+	url := fmt.Sprintf("http://localhost:%d%s", p.config.AppPort, r.URL.Path)
+	req, err := http.NewRequest(r.Method, url, r.Body)
+	if err != nil {
+		log.Fatalf("proxy could not create request, err: %+v\n", err)
+	}
+	req.Header.Set("X-Forwarded-For", r.RemoteAddr)
+
+	client := &http.Client{}
+	var resp *http.Response
+	for i := 0; i < 10; i++ {
+		resp, err = client.Do(req)
+		if err == nil {
+			break
+		}
+		if !errors.Is(err, syscall.ECONNREFUSED) {
+			log.Fatalf("proxy failed to call %s, err: %+v\n", url, err)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	defer resp.Body.Close()
+
+	// copy all headers except Content-Length
+	for k, vv := range resp.Header {
+		for _, v := range vv {
+			if k == "Content-Length" {
+				continue
+			}
+			w.Header().Add(k, v)
+		}
+	}
+	w.WriteHeader(resp.StatusCode)
+
+	if strings.Contains(resp.Header.Get("Content-Type"), "text/html") {
+		s := p.injectLiveReload(r.URL.String(), resp.Body)
+		w.Header().Set("Content-Length", strconv.Itoa((len([]byte(s)))))
+		if _, err := io.WriteString(w, s); err != nil {
+			log.Fatalf("proxy failed injected live reloading script, err: %+v\n", err)
+		}
+	} else {
+		w.Header().Set("Content-Length", resp.Header.Get("Content-Length"))
+		if _, err := io.Copy(w, resp.Body); err != nil {
+			log.Fatalf("proxy failed to forward request, err: %+v\n", err)
+		}
+	}
+}
+
+func (p *Proxy) reloadHandler(w http.ResponseWriter, r *http.Request) {
+	flusher, err := w.(http.Flusher)
+	if !err {
+		http.Error(w, "Streaming unsupported!", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+
+	sub := p.stream.AddSubscriber()
+	go func() {
+		<-r.Context().Done()
+		p.stream.RemoveSubscriber(sub.id)
+	}()
+
+	w.WriteHeader(http.StatusOK)
+	flusher.Flush()
+
+	for range sub.reloadCh {
+		fmt.Fprintf(w, "data: reload\n\n")
+		flusher.Flush()
+	}
+}

--- a/runner/proxy.go
+++ b/runner/proxy.go
@@ -43,7 +43,7 @@ func (p *Proxy) Run() {
 	http.HandleFunc("/", p.proxyHandler)
 	http.HandleFunc("/internal/reload", p.reloadHandler)
 	if err := p.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-		log.Fatal(err)
+		log.Fatalf("failed to start proxy server: %v", err)
 	}
 }
 

--- a/runner/proxy_stream.go
+++ b/runner/proxy_stream.go
@@ -1,0 +1,50 @@
+package runner
+
+import (
+	"sync"
+)
+
+type ProxyStream struct {
+	sync.Mutex
+	subscribers map[int]*Subscriber
+	count       int
+}
+
+type Subscriber struct {
+	id       int
+	reloadCh chan struct{}
+}
+
+func NewProxyStream() *ProxyStream {
+	return &ProxyStream{subscribers: make(map[int]*Subscriber)}
+}
+
+func (stream *ProxyStream) Stop() {
+	for id := range stream.subscribers {
+		stream.RemoveSubscriber(id)
+	}
+	stream.count = 0
+}
+
+func (stream *ProxyStream) AddSubscriber() *Subscriber {
+	stream.Lock()
+	defer stream.Unlock()
+	stream.count++
+
+	sub := &Subscriber{id: stream.count, reloadCh: make(chan struct{})}
+	stream.subscribers[stream.count] = sub
+	return sub
+}
+
+func (stream *ProxyStream) RemoveSubscriber(id int) {
+	stream.Lock()
+	defer stream.Unlock()
+	close(stream.subscribers[id].reloadCh)
+	delete(stream.subscribers, id)
+}
+
+func (stream *ProxyStream) Reload() {
+	for _, sub := range stream.subscribers {
+		sub.reloadCh <- struct{}{}
+	}
+}

--- a/runner/proxy_stream_test.go
+++ b/runner/proxy_stream_test.go
@@ -1,0 +1,66 @@
+package runner
+
+import (
+	"sync"
+	"testing"
+)
+
+func find(s map[int]*Subscriber, id int) bool {
+	for _, sub := range s {
+		if sub.id == id {
+			return true
+		}
+	}
+	return false
+}
+
+func TestProxyStream(t *testing.T) {
+	stream := NewProxyStream()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_ = stream.AddSubscriber()
+		}(i)
+	}
+	wg.Wait()
+
+	if got, exp := len(stream.subscribers), 10; got != exp {
+		t.Errorf("expected %d but got %d", exp, got)
+	}
+
+	go func() {
+		stream.Reload()
+	}()
+
+	reloadCount := 0
+	for _, sub := range stream.subscribers {
+		wg.Add(1)
+		go func(sub *Subscriber) {
+			defer wg.Done()
+			<-sub.reloadCh
+			reloadCount++
+		}(sub)
+	}
+	wg.Wait()
+
+	if got, exp := reloadCount, 10; got != exp {
+		t.Errorf("expected %d but got %d", exp, got)
+	}
+
+	stream.RemoveSubscriber(2)
+	stream.AddSubscriber()
+	if got, exp := find(stream.subscribers, 2), false; got != exp {
+		t.Errorf("expected subscriber found to be %t but got %t", exp, got)
+	}
+	if got, exp := find(stream.subscribers, 11), true; got != exp {
+		t.Errorf("expected subscriber found to be %t but got %t", exp, got)
+	}
+
+	stream.Stop()
+	if got, exp := len(stream.subscribers), 0; got != exp {
+		t.Errorf("expected %d but got %d", exp, got)
+	}
+}

--- a/runner/proxy_test.go
+++ b/runner/proxy_test.go
@@ -1,0 +1,132 @@
+package runner
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strconv"
+	"sync"
+	"testing"
+)
+
+type reloader struct {
+	subCh    chan struct{}
+	reloadCh chan struct{}
+}
+
+func (r *reloader) AddSubscriber() *Subscriber {
+	r.subCh <- struct{}{}
+	return &Subscriber{reloadCh: r.reloadCh}
+}
+
+func (r *reloader) RemoveSubscriber(_ int) {
+	close(r.subCh)
+}
+
+func (r *reloader) Reload() {}
+func (r *reloader) Stop()   {}
+
+func setupMockServer(t *testing.T) (srv *httptest.Server, port int) {
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "thin air")
+	}))
+	mockURL, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	port, err = strconv.Atoi(mockURL.Port())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return srv, port
+}
+
+func TestNewProxy(t *testing.T) {
+	_ = os.Unsetenv(airWd)
+	cfg := &cfgProxy{
+		Enabled:   true,
+		ProxyPort: 1111,
+		AppPort:   2222,
+	}
+	proxy := NewProxy(cfg)
+	if proxy.config == nil {
+		t.Fatal("config should not be nil")
+	}
+	if proxy.server.Addr == "" {
+		t.Fatal("server address should not be nil")
+	}
+}
+
+func TestProxy_proxyHandler(t *testing.T) {
+	srv, mockPort := setupMockServer(t)
+	defer srv.Close()
+
+	cfg := &cfgProxy{
+		Enabled:   true,
+		ProxyPort: 8090,
+		AppPort:   mockPort,
+	}
+	proxy := NewProxy(cfg)
+
+	req := httptest.NewRequest("GET", "http://localhost:8090/", nil)
+	rec := httptest.NewRecorder()
+
+	proxy.proxyHandler(rec, req)
+	resp := rec.Result()
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	if got, exp := string(bodyBytes), "thin air"; got != exp {
+		t.Errorf("expected %q but got %q", exp, got)
+	}
+}
+
+func TestProxy_reloadHandler(t *testing.T) {
+	srv, mockPort := setupMockServer(t)
+	defer srv.Close()
+
+	reloader := &reloader{subCh: make(chan struct{}), reloadCh: make(chan struct{})}
+	cfg := &cfgProxy{
+		Enabled:   true,
+		ProxyPort: 8090,
+		AppPort:   mockPort,
+	}
+	proxy := &Proxy{
+		config: cfg,
+		server: &http.Server{
+			Addr: "localhost:8090",
+		},
+		stream: reloader,
+	}
+
+	req := httptest.NewRequest("GET", "http://localhost:8090/internal/reload", nil)
+	rec := httptest.NewRecorder()
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		proxy.reloadHandler(rec, req)
+	}()
+
+	// wait for subscriber to be added
+	<-reloader.subCh
+
+	// send a reload event and wait for http response
+	reloader.reloadCh <- struct{}{}
+	close(reloader.reloadCh)
+	wg.Wait()
+
+	if !rec.Flushed {
+		t.Errorf("request should have been flushed")
+	}
+
+	resp := rec.Result()
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Errorf("reading body: %v", err)
+	}
+	if got, exp := string(bodyBytes), "data: reload\n\n"; got != exp {
+		t.Errorf("expected %q but got %q", exp, got)
+	}
+}

--- a/runner/proxy_test.go
+++ b/runner/proxy_test.go
@@ -1,6 +1,8 @@
 package runner
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -8,8 +10,11 @@ import (
 	"net/url"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type reloader struct {
@@ -29,19 +34,18 @@ func (r *reloader) RemoveSubscriber(_ int) {
 func (r *reloader) Reload() {}
 func (r *reloader) Stop()   {}
 
-func setupMockServer(t *testing.T) (srv *httptest.Server, port int) {
-	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, "thin air")
-	}))
+var proxyPort = 8090
+
+func getServerPort(t *testing.T, srv *httptest.Server) int {
 	mockURL, err := url.Parse(srv.URL)
 	if err != nil {
 		t.Fatal(err)
 	}
-	port, err = strconv.Atoi(mockURL.Port())
+	port, err := strconv.Atoi(mockURL.Port())
 	if err != nil {
 		t.Fatal(err)
 	}
-	return srv, port
+	return port
 }
 
 func TestNewProxy(t *testing.T) {
@@ -61,46 +65,104 @@ func TestNewProxy(t *testing.T) {
 }
 
 func TestProxy_proxyHandler(t *testing.T) {
-	srv, mockPort := setupMockServer(t)
-	defer srv.Close()
-
-	cfg := &cfgProxy{
-		Enabled:   true,
-		ProxyPort: 8090,
-		AppPort:   mockPort,
+	tests := []struct {
+		name   string
+		req    func() *http.Request
+		assert func(*http.Request)
+	}{
+		{
+			name: "get_request_with_headers",
+			assert: func(resp *http.Request) {
+				assert.Equal(t, "bar", resp.Header.Get("foo"))
+			},
+			req: func() *http.Request {
+				req := httptest.NewRequest("GET", fmt.Sprintf("http://localhost:%d", proxyPort), nil)
+				req.Header.Set("foo", "bar")
+				return req
+			},
+		},
+		{
+			name: "post_form_request",
+			req: func() *http.Request {
+				formData := url.Values{}
+				formData.Add("foo", "bar")
+				req := httptest.NewRequest("POST", fmt.Sprintf("http://localhost:%d", proxyPort), strings.NewReader(formData.Encode()))
+				req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+				return req
+			},
+			assert: func(resp *http.Request) {
+				assert.NoError(t, resp.ParseForm())
+				assert.Equal(t, resp.Form.Get("foo"), "bar")
+			},
+		},
+		{
+			name: "get_request_with_query_string",
+			req: func() *http.Request {
+				return httptest.NewRequest("GET", fmt.Sprintf("http://localhost:%d?q=%s", proxyPort, "air"), nil)
+			},
+			assert: func(resp *http.Request) {
+				q := resp.URL.Query()
+				assert.Equal(t, q.Encode(), "q=air")
+			},
+		},
+		{
+			name: "put_json_request",
+			req: func() *http.Request {
+				body := []byte(`{"foo": "bar"}`)
+				req := httptest.NewRequest("PUT", fmt.Sprintf("http://localhost:%d/a/b/c", proxyPort), bytes.NewBuffer(body))
+				req.Header.Set("Content-Type", "application/json; charset=UTF-8")
+				return req
+			},
+			assert: func(resp *http.Request) {
+				type Response struct {
+					Foo string `json:"foo"`
+				}
+				var r Response
+				assert.NoError(t, json.NewDecoder(resp.Body).Decode(&r))
+				assert.Equal(t, resp.URL.Path, "/a/b/c")
+				assert.Equal(t, r.Foo, "bar")
+			},
+		},
 	}
-	proxy := NewProxy(cfg)
-
-	req := httptest.NewRequest("GET", "http://localhost:8090/", nil)
-	rec := httptest.NewRecorder()
-
-	proxy.proxyHandler(rec, req)
-	resp := rec.Result()
-	bodyBytes, _ := io.ReadAll(resp.Body)
-	if got, exp := string(bodyBytes), "thin air"; got != exp {
-		t.Errorf("expected %q but got %q", exp, got)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				tt.assert(r)
+			}))
+			defer srv.Close()
+			srvPort := getServerPort(t, srv)
+			proxy := NewProxy(&cfgProxy{
+				Enabled:   true,
+				ProxyPort: proxyPort,
+				AppPort:   srvPort,
+			})
+			proxy.proxyHandler(httptest.NewRecorder(), tt.req())
+		})
 	}
 }
 
 func TestProxy_reloadHandler(t *testing.T) {
-	srv, mockPort := setupMockServer(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, "thin air")
+	}))
+	srvPort := getServerPort(t, srv)
 	defer srv.Close()
 
 	reloader := &reloader{subCh: make(chan struct{}), reloadCh: make(chan struct{})}
 	cfg := &cfgProxy{
 		Enabled:   true,
-		ProxyPort: 8090,
-		AppPort:   mockPort,
+		ProxyPort: proxyPort,
+		AppPort:   srvPort,
 	}
 	proxy := &Proxy{
 		config: cfg,
 		server: &http.Server{
-			Addr: "localhost:8090",
+			Addr: fmt.Sprintf("localhost:%d", proxyPort),
 		},
 		stream: reloader,
 	}
 
-	req := httptest.NewRequest("GET", "http://localhost:8090/internal/reload", nil)
+	req := httptest.NewRequest("GET", fmt.Sprintf("http://localhost:%d/internal/reload", proxyPort), nil)
 	rec := httptest.NewRecorder()
 	var wg sync.WaitGroup
 	wg.Add(1)


### PR DESCRIPTION
## Description
This PR implements what is discussed in this issue: https://github.com/cosmtrek/air/issues/141. I started a new webapp using Go templates and would like to have a live reloading functionality (not just hot reloading when files change). The two possible implementations are with websockets or with server-sent events. I chose the latter because it adds the least amount of complexity and no external dependency is required. I'd like some feedback on the config names (port and app_port, or frontend_port and backend_port?) and whether proxy should be enabled by default or not.

## How to use
It is quite simple to use, add the proxy config, in my case I added my views containing the go templates on `include_dir`, and access the proxy port, e.g. `http://localhost:8090`.

## How it works
There are two handlers on the proxy, the root handler `/` which is a catch-all and should proxy all requests and the `/internal/reload` endpoint which implements server-sent events. The root handler proxies all the requests and injects a script that listens to `/internal/reload` and reloads the browser every time air watches a file change.

