### PR TITLE
Fix garbled encoding issue when build fails on non-Latin Windows systems

### DIFF
--- a/runner/util_windows.go
+++ b/runner/util_windows.go
@@ -20,7 +20,7 @@ func (e *Engine) startCmd(cmd string) (*exec.Cmd, io.ReadCloser, io.ReadCloser, 
 	if !strings.Contains(cmd, ".exe") {
 		e.runnerLog("CMD will not recognize non .exe file for execution, path: %s", cmd)
 	}
-	c := exec.Command("cmd", "/c", cmd)
+	c := exec.Command("cmd", "/c", "@chcp 65001 >nul && "+cmd)
 	stderr, err := c.StderrPipe()
 	if err != nil {
 		return nil, nil, nil, err


### PR DESCRIPTION
The default encoding in Go is UTF-8. However, when `cmd.exe` is run on non-Latin Windows systems, it may use an encoding other than UTF-8, which can lead to garbled text.

This patch addresses the issue by running `chcp` to set the code page to UTF-8 before executing commands.

Reproduce(run on a non-latin Windows):

```bash
air init
```

Then modify the `.air.toml`:

```
  bin = "tmp\\main.exe"
  cmd = "go build -o ./tmp/main.exe ."
```

To(leave `tmp_dir` alone)

```
  bin = "bin\\main.exe"
  cmd = "go build -o ./bin/main.exe ."
```

Before this patch:

![image](https://github.com/cosmtrek/air/assets/14011681/9bddcb42-8526-4d77-83e1-44e8a928b55c)

After:

![image](https://github.com/cosmtrek/air/assets/14011681/28830842-68ad-483e-9f73-51a5303c0367)

