### PR TITLE
fix: fix proxy error handling and race conditions

### DIFF
--- a/runner/engine.go
+++ b/runner/engine.go
@@ -591,7 +591,9 @@ func (e *Engine) cleanup() {
 
 	if e.config.Proxy.Enabled {
 		e.mainDebug("powering down the proxy...")
-		e.proxy.Stop()
+		if err := e.proxy.Stop(); err != nil {
+			e.mainLog("failed to stop proxy: %+v", err)
+		}
 	}
 
 	e.withLock(func() {

--- a/runner/proxy.go
+++ b/runner/proxy.go
@@ -15,7 +15,7 @@ import (
 
 type Reloader interface {
 	AddSubscriber() *Subscriber
-	RemoveSubscriber(id int)
+	RemoveSubscriber(id int32)
 	Reload()
 	Stop()
 }

--- a/runner/proxy_stream.go
+++ b/runner/proxy_stream.go
@@ -6,7 +6,7 @@ import (
 )
 
 type ProxyStream struct {
-	mu          sync.RWMutex
+	mu          sync.Mutex
 	subscribers map[int32]*Subscriber
 	count       atomic.Int32
 }

--- a/runner/proxy_stream.go
+++ b/runner/proxy_stream.go
@@ -2,45 +2,49 @@ package runner
 
 import (
 	"sync"
+	"sync/atomic"
 )
 
 type ProxyStream struct {
-	sync.Mutex
-	subscribers map[int]*Subscriber
-	count       int
+	mu          sync.RWMutex
+	subscribers map[int32]*Subscriber
+	count       atomic.Int32
 }
 
 type Subscriber struct {
-	id       int
+	id       int32
 	reloadCh chan struct{}
 }
 
 func NewProxyStream() *ProxyStream {
-	return &ProxyStream{subscribers: make(map[int]*Subscriber)}
+	return &ProxyStream{subscribers: make(map[int32]*Subscriber)}
 }
 
 func (stream *ProxyStream) Stop() {
 	for id := range stream.subscribers {
 		stream.RemoveSubscriber(id)
 	}
-	stream.count = 0
+	stream.count = atomic.Int32{}
 }
 
 func (stream *ProxyStream) AddSubscriber() *Subscriber {
-	stream.Lock()
-	defer stream.Unlock()
-	stream.count++
+	stream.mu.Lock()
+	defer stream.mu.Unlock()
+	stream.count.Add(1)
 
-	sub := &Subscriber{id: stream.count, reloadCh: make(chan struct{})}
-	stream.subscribers[stream.count] = sub
+	sub := &Subscriber{id: stream.count.Load(), reloadCh: make(chan struct{})}
+	stream.subscribers[stream.count.Load()] = sub
 	return sub
 }
 
-func (stream *ProxyStream) RemoveSubscriber(id int) {
-	stream.Lock()
-	defer stream.Unlock()
-	close(stream.subscribers[id].reloadCh)
-	delete(stream.subscribers, id)
+func (stream *ProxyStream) RemoveSubscriber(id int32) {
+	stream.mu.Lock()
+	defer stream.mu.Unlock()
+
+	if _, ok := stream.subscribers[id]; ok {
+		close(stream.subscribers[id].reloadCh)
+		delete(stream.subscribers, id)
+	}
 }
 
 func (stream *ProxyStream) Reload() {

--- a/runner/proxy_test.go
+++ b/runner/proxy_test.go
@@ -27,7 +27,7 @@ func (r *reloader) AddSubscriber() *Subscriber {
 	return &Subscriber{reloadCh: r.reloadCh}
 }
 
-func (r *reloader) RemoveSubscriber(_ int) {
+func (r *reloader) RemoveSubscriber(_ int32) {
 	close(r.subCh)
 }
 

--- a/runner/proxy_test.go
+++ b/runner/proxy_test.go
@@ -48,7 +48,7 @@ func getServerPort(t *testing.T, srv *httptest.Server) int {
 	return port
 }
 
-func TestNewProxy(t *testing.T) {
+func TestProxy_run(t *testing.T) {
 	_ = os.Unsetenv(airWd)
 	cfg := &cfgProxy{
 		Enabled:   true,
@@ -62,6 +62,12 @@ func TestNewProxy(t *testing.T) {
 	if proxy.server.Addr == "" {
 		t.Fatal("server address should not be nil")
 	}
+	go func() {
+		proxy.Run()
+	}()
+	if err := proxy.Stop(); err != nil {
+		t.Errorf("failed stopping the proxy: %v", err)
+	}
 }
 
 func TestProxy_proxyHandler(t *testing.T) {
@@ -72,13 +78,13 @@ func TestProxy_proxyHandler(t *testing.T) {
 	}{
 		{
 			name: "get_request_with_headers",
-			assert: func(resp *http.Request) {
-				assert.Equal(t, "bar", resp.Header.Get("foo"))
-			},
 			req: func() *http.Request {
 				req := httptest.NewRequest("GET", fmt.Sprintf("http://localhost:%d", proxyPort), nil)
 				req.Header.Set("foo", "bar")
 				return req
+			},
+			assert: func(resp *http.Request) {
+				assert.Equal(t, "bar", resp.Header.Get("foo"))
 			},
 		},
 		{
@@ -137,6 +143,66 @@ func TestProxy_proxyHandler(t *testing.T) {
 				AppPort:   srvPort,
 			})
 			proxy.proxyHandler(httptest.NewRecorder(), tt.req())
+		})
+	}
+}
+
+func TestProxy_injectLiveReload(t *testing.T) {
+	tests := []struct {
+		name   string
+		given  *http.Response
+		expect string
+	}{
+		{
+			name: "when_no_body_should_not_be_injected",
+			given: &http.Response{
+				Proto:      "HTTP/1.1",
+				ProtoMajor: 1,
+				ProtoMinor: 1,
+				StatusCode: http.StatusOK,
+				Body:       http.NoBody,
+			},
+			expect: "",
+		},
+		{
+			name: "when_missing_body_should_not_be_injected",
+			given: &http.Response{
+				Proto:      "HTTP/1.1",
+				ProtoMajor: 1,
+				ProtoMinor: 1,
+				StatusCode: http.StatusOK,
+				Header: http.Header{
+					"Content-Type": []string{"text/html"},
+				},
+				Body: io.NopCloser(strings.NewReader(`<h1>test</h1>`)),
+			},
+			expect: "<h1>test</h1>",
+		},
+		{
+			name: "when_text_html_and_body_is_present_should_be_injected",
+			given: &http.Response{
+				Proto:      "HTTP/1.1",
+				ProtoMajor: 1,
+				ProtoMinor: 1,
+				StatusCode: http.StatusOK,
+				Header: http.Header{
+					"Content-Type": []string{"text/html"},
+				},
+				Body: io.NopCloser(strings.NewReader(`<body><h1>test</h1></body>`)),
+			},
+			expect: `<body><h1>test</h1><script>new EventSource("http://localhost:1111/internal/reload").onmessage = () => { location.reload() }</script></body>`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			proxy := NewProxy(&cfgProxy{
+				Enabled:   true,
+				ProxyPort: 1111,
+				AppPort:   2222,
+			})
+			if got, _ := proxy.injectLiveReload(tt.given); got != tt.expect {
+				t.Errorf("expected page %+v, got %v", tt.expect, got)
+			}
 		})
 	}
 }


### PR DESCRIPTION
I improved the error handling by avoiding log.Fatal as much as possible which doesn't clean up the resources properly (leaving the process and ports open). I couldn't reproduce [this issue](https://github.com/cosmtrek/air/issues/584) with the steps mentioned but after running `go test -v -count=1 -race -run TestProxyStream ./runner` a few times I got some race condition warnings. You can run those tests to validate the new behaviour (with atomic counters and RWMutex) working as expected with no warnings. I also added a CORS wildcard allow asked in another issue.