### PR TITLE
Fix: Proxy return redirect response

### DIFF
--- a/runner/proxy.go
+++ b/runner/proxy.go
@@ -33,7 +33,11 @@ func NewProxy(cfg *cfgProxy) *Proxy {
 		server: &http.Server{
 			Addr: fmt.Sprintf(":%d", cfg.ProxyPort),
 		},
-		client: &http.Client{},
+		client: &http.Client{
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
 		stream: NewProxyStream(),
 	}
 	return p


### PR DESCRIPTION
## What has been changed
Configures proxy to not follow redirects and return to the client the actual response from the server.

## Why?
Current proxy solution "follows" redirect responses from the server and makes an additional request rather then returning the redirect response to the client.

## Example Scenario
Client issues a delete request and the server returns a See Other redirect response. Current proxy solution does not return the response but follows the redirect response, makes another request and then returns that response to the client.

### Before the change:
<img width="861" alt="image" src="https://github.com/cosmtrek/air/assets/5693892/9d03a7af-6f91-4f63-950f-21909e3990da">
<img width="420" alt="image" src="https://github.com/cosmtrek/air/assets/5693892/0473b6ba-a988-482e-9441-38ef3a00cf4e">

### After the change:
<img width="874" alt="image" src="https://github.com/cosmtrek/air/assets/5693892/9305c8fd-cca9-49fb-8152-4a5a43733e9f">
<img width="419" alt="image" src="https://github.com/cosmtrek/air/assets/5693892/a2956ca2-d2be-433b-a3f2-9c936fcbd769">

