### PR TITLE
fix: add golangci-lint setup action and fix lint issue

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,11 +20,14 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: ^1.22
-
-      - name: Build
-        run: make build
+      - name: Install golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.59
       - name: Install dependency
         run: if [ $(uname) == "Darwin" ]; then brew install gnu-sed ;fi
+      - name: Build
+        run: make build
       - name: Run unit tests
         run: go install github.com/go-delve/delve/cmd/dlv@latest && go test ./... -v -covermode=count -coverprofile=coverage.txt
       - name: Upload Coverage report to CodeCov

--- a/runner/proxy.go
+++ b/runner/proxy.go
@@ -34,7 +34,7 @@ func NewProxy(cfg *cfgProxy) *Proxy {
 			Addr: fmt.Sprintf(":%d", cfg.ProxyPort),
 		},
 		client: &http.Client{
-			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
 				return http.ErrUseLastResponse
 			},
 		},


### PR DESCRIPTION
The `make check` linting step failed: https://github.com/cosmtrek/air/actions/runs/9240465156/job/25420774320. The build step running in each PR is broken with `golangci-lint: command not found` issue: https://github.com/cosmtrek/air/actions/runs/9149739894/job/25364966455#step:4:13