### PR TITLE
fix: build with 1.25 - issue 790

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
         id: go
         uses: actions/setup-go@v5
         with:
-          go-version: ^1.24
+          go-version: ^1.25
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:


### PR DESCRIPTION
Fix for https://github.com/air-verse/air/issues/790

Related mr https://github.com/air-verse/air/pull/794

## See also

- https://youtrack.jetbrains.com/issue/GO-19210/Debugger-is-not-working-after-update-to-go-version-1.25.0#focus=Change-27-12530951.0-0