### PR TITLE
feat: add option to skip deleting the binary on rebuild

### DIFF
--- a/runner/config.go
+++ b/runner/config.go
@@ -60,6 +60,7 @@ type cfgBuild struct {
 	KillDelay        time.Duration `toml:"kill_delay" usage:"Delay after sending Interrupt signal"`
 	Rerun            bool          `toml:"rerun" usage:"Rerun binary or not"`
 	RerunDelay       int           `toml:"rerun_delay" usage:"Delay after each execution"`
+	DeleteBin        bool          `toml:"delete_bin" usage:"Delete binary before building"`
 	regexCompiled    []*regexp.Regexp
 }
 
@@ -225,6 +226,7 @@ func defaultConfig() Config {
 		Delay:        1000,
 		Rerun:        false,
 		RerunDelay:   500,
+		DeleteBin:    true,
 	}
 	if runtime.GOOS == PlatformWindows {
 		build.Bin = `tmp\main.exe`

--- a/runner/engine.go
+++ b/runner/engine.go
@@ -562,8 +562,12 @@ func (e *Engine) runBin() error {
 				if _, err = os.Stat(cmdBinPath); os.IsNotExist(err) {
 					return
 				}
+				if !e.config.Build.DeleteBin {
+					e.mainLog("skpping deletion of %s as per config", cmdBinPath)
+					return
+				}
 				if err = os.Remove(cmdBinPath); err != nil {
-					e.mainLog("failed to remove %s, error: %s", e.config.rel(e.config.binPath()), err)
+					e.mainLog("failed to remove %s, error: %s", cmdBinPath, err)
 				}
 			}
 		}()


### PR DESCRIPTION
Hello,

I noticed a small issue with the way air works. In my setup I am using delve to run the binary so as I can attach from my editor and debug. The issue is that delve gets interpreted as the build out and gets deleted on rebuild resulting in a `file not found` error when it tries to run it again. My current solution is to use `cp /go/bin/dlv dlv` as a pre-run cmd but I believe the solution this PR proposes is much better. I am adding a `delete_bin` option that can be set to `false` so as the binary will not be deleted allowing the user of debugger programs or wrappers to execute the main program. This will also cause any issues with go since it overwrites the binary by default. Let me know if you need anything changed.