### PR TITLE
Set default build bin

### DIFF
--- a/runner/config.go
+++ b/runner/config.go
@@ -275,8 +275,8 @@ func readConfByName(name string) (*Config, error) {
 func defaultConfig() Config {
 	build := cfgBuild{
 		Cmd:          "go build -o ./tmp/main .",
-		Bin:          "",
-		Entrypoint:   entrypoint{"./tmp/main"},
+		Bin:          "./tmp/main",
+		Entrypoint:   entrypoint{},
 		Log:          "build-errors.log",
 		IncludeExt:   []string{"go", "tpl", "tmpl", "html"},
 		IncludeDir:   []string{},

--- a/runner/config_test.go
+++ b/runner/config_test.go
@@ -118,7 +118,7 @@ func TestConfPreprocess(t *testing.T) {
 		t.Fatalf("preprocess error %v", err)
 	}
 	suffix := "/_testdata/toml/tmp/main"
-	binPath := df.Build.Entrypoint.binary()
+	binPath := df.Build.Bin
 	if !strings.HasSuffix(binPath, suffix) {
 		t.Fatalf("bin path is %s, but not have suffix  %s.", binPath, suffix)
 	}


### PR DESCRIPTION
This pull request updates the handling of the build binary path in the configuration logic, ensuring more consistent and predictable behavior. The main focus is on simplifying how the binary path is set and accessed in both the configuration and the tests.

Configuration improvements:

* Set the `Bin` field in the `cfgBuild` struct to `./tmp/main` by default, and reset the `Entrypoint` field to an empty value in `defaultConfig()`, making the binary path explicit and easier to reference.

Test adjustments:

* Updated the test in `config_test.go` to reference the `Bin` field directly instead of using the `Entrypoint.binary()` method, aligning the test with the new configuration structure.