### PR TITLE
fix: create nested tmp_dir paths

### DIFF
--- a/runner/engine.go
+++ b/runner/engine.go
@@ -123,7 +123,7 @@ func (e *Engine) checkRunEnv() error {
 	p := e.config.tmpPath()
 	if _, err := os.Stat(p); os.IsNotExist(err) {
 		e.runnerLog("mkdir %s", p)
-		if err := os.Mkdir(p, 0o755); err != nil {
+		if err := os.MkdirAll(p, 0o755); err != nil {
 			e.runnerLog("failed to mkdir, error: %s", err.Error())
 			return err
 		}

--- a/runner/engine_test.go
+++ b/runner/engine_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
@@ -17,6 +18,7 @@ import (
 
 	"github.com/pelletier/go-toml"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewEngine(t *testing.T) {
@@ -42,10 +44,12 @@ func TestCheckRunEnv(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Should not be fail: %s.", err)
 	}
+	nestedTmpDir := filepath.Join(t.TempDir(), "nested", "build")
+	engine.config.TmpDir = nestedTmpDir
+
 	err = engine.checkRunEnv()
-	if err == nil {
-		t.Fatal("should throw a err")
-	}
+	require.NoError(t, err)
+	assert.DirExists(t, nestedTmpDir)
 }
 
 func TestWatching(t *testing.T) {


### PR DESCRIPTION
close https://github.com/air-verse/air/issues/505
This pull request improves the robustness of the temporary directory creation logic in the engine and updates the associated unit test to ensure correct behavior. The main changes include switching to recursive directory creation and refining the test to verify nested directory handling.

### Temporary directory creation improvements

* Updated `checkRunEnv` in `runner/engine.go` to use `os.MkdirAll` instead of `os.Mkdir`, allowing the creation of nested directories if they do not exist.

### Unit test enhancements

* Modified `TestCheckRunEnv` in `runner/engine_test.go` to set a nested temporary directory path, check for errors using `require.NoError`, and assert that the nested directory exists after running the environment check.

### Test dependencies

* Added imports for `filepath` and `github.com/stretchr/testify/require` in `runner/engine_test.go` to support nested path creation and improved assertions. [[1]](diffhunk://#diff-c484509c25b7c8e4df331c9aefcbb49e43881a9a57c201a4491a4b7b61a72acbR11) [[2]](diffhunk://#diff-c484509c25b7c8e4df331c9aefcbb49e43881a9a57c201a4491a4b7b61a72acbR21)