### PR TITLE
Fix PowerShell full_bin startup command

### DIFF
--- a/runner/util.go
+++ b/runner/util.go
@@ -361,7 +361,11 @@ func adaptToVariousPlatforms(c *Config) {
 					exe += extName
 				}
 
-				c.Build.FullBin = fmt.Sprintf(`Start-Process -FilePath "%s" -ArgumentList "%s" -Wait -NoNewWindow`, exe, args)
+				if strings.TrimSpace(args) == "" {
+					c.Build.FullBin = fmt.Sprintf(`Start-Process -FilePath "%s" -Wait -NoNewWindow`, exe)
+				} else {
+					c.Build.FullBin = fmt.Sprintf(`Start-Process -FilePath "%s" -ArgumentList "%s" -Wait -NoNewWindow`, exe, args)
+				}
 			} else {
 				if !strings.HasSuffix(strings.ToLower(c.Build.FullBin), extName) {
 					c.Build.FullBin += extName

--- a/runner/util_test.go
+++ b/runner/util_test.go
@@ -234,6 +234,36 @@ func TestAdaptToVariousPlatforms_PowershellFullBin(t *testing.T) {
 	assert.Equal(t, expected, config.Build.FullBin)
 }
 
+func TestAdaptToVariousPlatforms_PowershellFullBinWithoutArgs(t *testing.T) {
+	adaptPlatformMu.Lock()
+	originalGOOS := getGOOSFunc
+	originalIsPowershell := isPowershellFunc
+
+	getGOOSFunc = func() string {
+		return PlatformWindows
+	}
+	isPowershellFunc = func() bool {
+		return true
+	}
+
+	t.Cleanup(func() {
+		getGOOSFunc = originalGOOS
+		isPowershellFunc = originalIsPowershell
+		adaptPlatformMu.Unlock()
+	})
+
+	config := &Config{
+		Build: cfgBuild{
+			FullBin: "\"C:\\Program Files\\Acme App\\app\"",
+		},
+	}
+
+	adaptToVariousPlatforms(config)
+
+	expected := `Start-Process -FilePath "C:\Program Files\Acme App\app.exe" -Wait -NoNewWindow`
+	assert.Equal(t, expected, config.Build.FullBin)
+}
+
 func Test_killCmd_SendInterrupt_false(t *testing.T) {
 	_, b, _, _ := runtime.Caller(0)
 


### PR DESCRIPTION
fix for this issue: https://github.com/air-verse/air/issues/775
This pull request improves Windows platform support in the runner utility by adding explicit handling for PowerShell and enhancing test coverage. The main changes include detecting PowerShell, adapting command execution for PowerShell, and introducing new tests to ensure correct behavior.

**Platform detection and adaptation:**

* Added a new `isPowershell()` function in `runner/util.go` to detect if the environment is PowerShell, using an actual process check.
* Refactored platform detection logic in `adaptToVariousPlatforms` to use injectable functions (`getGOOSFunc` and `isPowershellFunc`), allowing easier testing and customization.
* Updated Windows command adaptation in `adaptToVariousPlatforms` to generate PowerShell-specific command lines when running under PowerShell, improving compatibility for complex executable paths and arguments.

**Testing improvements:**

* Added a mutex (`adaptPlatformMu`) in `runner/util_test.go` to ensure thread safety when modifying global test hooks.
* Added a new test `TestAdaptToVariousPlatforms_PowershellFullBin` to verify correct PowerShell command construction for executables with spaces and arguments.
* Updated `TestAdaptToVariousPlatforms` to use the mutex for safe test execution.