### PR TITLE
fix: prevent running air in dangerous root directories

### DIFF
--- a/runner/config.go
+++ b/runner/config.go
@@ -368,6 +368,12 @@ func (c *Config) preprocess(args map[string]TomlInfo) error {
 	if err != nil {
 		return err
 	}
+
+	// Check for dangerous root directories that could cause excessive file watching
+	if isDangerous, dirName := isDangerousRoot(c.Root); isDangerous {
+		return fmt.Errorf("refusing to run in %s - this would watch too many files. Please run air in a project directory", dirName)
+	}
+
 	if c.TmpDir == "" {
 		c.TmpDir = "tmp"
 	}

--- a/runner/util.go
+++ b/runner/util.go
@@ -500,3 +500,36 @@ func formatPath(path string) string {
 
 	return quotedPath
 }
+
+// isDangerousRoot checks if the given path is a dangerous root directory
+// that could cause excessive file watching (home dir, root dir, etc.)
+// Returns true and a description if the path is dangerous.
+func isDangerousRoot(path string) (bool, string) {
+	// Get absolute path
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return false, ""
+	}
+	absPath = filepath.Clean(absPath)
+
+	// Check root directory
+	if absPath == "/" {
+		return true, "root directory (/)"
+	}
+
+	// Check home directory
+	home, err := os.UserHomeDir()
+	if err == nil {
+		home = filepath.Clean(home)
+		if absPath == home {
+			return true, "home directory (~)"
+		}
+	}
+
+	// Check /root (root user's home, in case UserHomeDir returns something else)
+	if absPath == "/root" {
+		return true, "/root directory"
+	}
+
+	return false, ""
+}


### PR DESCRIPTION
close https://github.com/air-verse/air/issues/761
Add safety check to refuse running in home directory, system root (/), or /root to prevent excessive file watching that could impact performance or system stability.

- Add isDangerousRoot() utility function to detect dangerous paths
- Integrate check in config.preprocess() with clear error message
- Add comprehensive tests for all dangerous path scenarios