### PR TITLE
Fix silent TOML parse errors causing exclude_dir to be ignored (#678)

### DIFF
--- a/runner/_testdata/invalid_toml/.air.toml
+++ b/runner/_testdata/invalid_toml/.air.toml
@@ -1,0 +1,6 @@
+# Config file with duplicate key to trigger parse error
+root = "."
+
+[build]
+delay = 1000
+delay = 2000

--- a/runner/config.go
+++ b/runner/config.go
@@ -256,6 +256,12 @@ func defaultPathConfig() (*Config, error) {
 		return cfg, nil
 	}
 
+	// If the config file exists but failed to parse, report the error
+	// Only use defaults if no config file exists
+	if !os.IsNotExist(err) {
+		return nil, fmt.Errorf("failed to parse %s: %w", dftTOML, err)
+	}
+
 	dftCfg := defaultConfig()
 	return &dftCfg, nil
 }

--- a/runner/config_test.go
+++ b/runner/config_test.go
@@ -111,6 +111,22 @@ func TestReadConfByName(t *testing.T) {
 	}
 }
 
+func TestDefaultPathConfigWithInvalidTOML(t *testing.T) {
+	// Test that defaultPathConfig returns an error when .air.toml exists but has parse errors
+	// This is a regression test for issue #678
+	t.Setenv(airWd, "_testdata/invalid_toml")
+	_, err := defaultPathConfig()
+	if err == nil {
+		t.Fatal("expected error when .air.toml has parse errors, but got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to parse") {
+		t.Fatalf("expected error message to contain 'failed to parse', got: %s", err.Error())
+	}
+	if !strings.Contains(err.Error(), "defined twice") {
+		t.Fatalf("expected error message to contain 'defined twice', got: %s", err.Error())
+	}
+}
+
 func TestConfPreprocess(t *testing.T) {
 	t.Setenv(airWd, "_testdata/toml")
 	df := defaultConfig()


### PR DESCRIPTION
close https://github.com/air-verse/air/issues/678