### PR TITLE
Added Homebrew installation instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ curl -sSfL https://goblin.run/github.com/air-verse/air | sh
 curl -sSfL https://goblin.run/github.com/air-verse/air | PREFIX=/tmp sh
 ```
 
+### Via [Homebrew](https://github.com/Homebrew/brew)
+
+```shell
+brew install go-air
+```
+
 ### Using software package manager [mise](https://github.com/jdx/mise)
 
 ```shell


### PR DESCRIPTION
Air is now available in the Homebrew core, so listing it as the option in installation instructions